### PR TITLE
Minor change in requirements.txt | removed comma (,)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.9.5,
-mysql-python==1.2.5,
-django-taggit==0.18.1,
+django==1.9.5
+mysql-python==1.2.5
+django-taggit==0.18.1
 pytz==2016.4


### PR DESCRIPTION
While running the command `pip install -r requirements.txt` the following error is observed:
"InvalidRequirement: Invalid requirement, parse error at "u',' "

Fix:
Removed ',' after each module name in requirements.txt to fix the error.