### PR TITLE
Removed for loop from the question template.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 # command to install dependencies
 install:
   - pip install git+https://github.com/FOSSEE/online_test.git#egg=yaksh-0.1
-  - pip install -q Django==$DJANGO --use-mirrors
+  - pip install -q Django==$DJANGO
   - pip install -q pytz==2016.4
   - pip install -q python-social-auth==0.2.19
 

--- a/yaksh/templates/yaksh/question.html
+++ b/yaksh/templates/yaksh/question.html
@@ -89,9 +89,7 @@ function call_skip(url)
 	{% if paper.questions_left  %}
 	window.setTimeout(function()
 	{   
-		{% for qid in paper.questions.all  %}
-        location.href="{{ URL_ROOT }}/exam/{{ qid.id }}/check/{{ paper.attempt_number }}/{{ paper.question_paper.id }}/"
-		{% endfor %}		
+        location.href="{{ URL_ROOT }}/exam/{{ paper.current_question.id }}/check/{{ paper.attempt_number }}/{{ paper.question_paper.id }}/"
 	}, 2000);
 	{% else %}
 	window.setTimeout(function()


### PR DESCRIPTION
Once the code question is correct, user must see the message Correct
Output for two seconds and then url redirection.
But since this was written in a for loop, so
multiple requests almost simultaneously were sent by a single user.
This caused the server to go down. For now removed for loop, which resolves the issue.