### PR TITLE
Stdio bugfixes

### DIFF
--- a/yaksh/bash_stdio_evaluator.py
+++ b/yaksh/bash_stdio_evaluator.py
@@ -40,7 +40,8 @@ class BashStdioEvaluator(StdIOEvaluator):
                                 shell=True,
                                 stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE
+                                stderr=subprocess.PIPE,
+                                preexec_fn=os.setpgrp
                                 )
         success, err = self.evaluate_stdio(user_answer, proc,
                                            expected_input,

--- a/yaksh/code_evaluator.py
+++ b/yaksh/code_evaluator.py
@@ -181,11 +181,14 @@ class CodeEvaluator(object):
         stdout and stderr.
         """
         try:
-            proc = subprocess.Popen(cmd_args, *args, **kw)
+            proc = subprocess.Popen(cmd_args,  preexec_fn=os.setpgrp, *args, **kw)
+            # Set the subprocess into a group process.
             stdout, stderr = proc.communicate()
         except TimeoutException:
             # Runaway code, so kill it.
-            proc.kill()
+            # kill the entire group.
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+
             # Re-raise exception.
             raise
         return proc, stdout.decode('utf-8'), stderr.decode('utf-8')

--- a/yaksh/cpp_stdio_evaluator.py
+++ b/yaksh/cpp_stdio_evaluator.py
@@ -74,7 +74,8 @@ class CppStdioEvaluator(StdIOEvaluator):
                                         shell=True,
                                         stdin=subprocess.PIPE,
                                         stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE
+                                        stderr=subprocess.PIPE,
+                                        preexec_fn=os.setpgrp
                                         )
                 success, err = self.evaluate_stdio(user_answer, proc,
                                                    expected_input,

--- a/yaksh/evaluator_tests/test_bash_evaluation.py
+++ b/yaksh/evaluator_tests/test_bash_evaluation.py
@@ -7,6 +7,7 @@ from yaksh.bash_code_evaluator import BashCodeEvaluator
 from yaksh.bash_stdio_evaluator import BashStdioEvaluator
 from yaksh.settings import SERVER_TIMEOUT
 from textwrap import dedent
+import subprocess
 
 
 class BashAssertionEvaluationTestCases(unittest.TestCase):
@@ -64,6 +65,7 @@ class BashAssertionEvaluationTestCases(unittest.TestCase):
         result = get_class.evaluate(**kwargs)
         self.assertFalse(result.get("success"))
         self.assertEqual(result.get("error"), self.timeout_msg)
+        self.assertEqual(1, subprocess.call(["pgrep", "submit.sh"]))
 
     def test_file_based_assert(self):
         self.file_paths = [('/tmp/test.txt', False)]

--- a/yaksh/evaluator_tests/test_c_cpp_evaluation.py
+++ b/yaksh/evaluator_tests/test_c_cpp_evaluation.py
@@ -7,7 +7,7 @@ from yaksh.cpp_code_evaluator import CppCodeEvaluator
 from yaksh.cpp_stdio_evaluator import CppStdioEvaluator
 from yaksh.settings import SERVER_TIMEOUT
 from textwrap import dedent
-
+import subprocess
 
 class CAssertionEvaluationTestCases(unittest.TestCase):
     def setUp(self):
@@ -70,6 +70,7 @@ class CAssertionEvaluationTestCases(unittest.TestCase):
         result = get_class.evaluate(**kwargs)
         self.assertFalse(result.get("success"))
         self.assertEqual(result.get("error"), self.timeout_msg)
+        self.assertEqual(1, subprocess.call(["pgrep", "executable"]))
 
     def test_file_based_assert(self):
         self.file_paths = [('/tmp/test.txt', False)]
@@ -204,6 +205,7 @@ class CppStdioEvaluationTestCases(unittest.TestCase):
         result = get_class.evaluate(**kwargs)
         self.assertFalse(result.get("success"))
         self.assertEqual(result.get("error"), self.timeout_msg)
+        self.assertEqual(1, subprocess.call(["pgrep", "java"]))
 
     def test_only_stdout(self):
         self.test_case_data = [{'expected_output': '11',
@@ -328,6 +330,7 @@ class CppStdioEvaluationTestCases(unittest.TestCase):
         result = get_class.evaluate(**kwargs)
         self.assertFalse(result.get("success"))
         self.assertEqual(result.get("error"), self.timeout_msg)
+        self.assertEqual(1, subprocess.call(["pgrep", "java"]))
 
     def test_cpp_only_stdout(self):
         self.test_case_data = [{'expected_output': '11',

--- a/yaksh/evaluator_tests/test_java_evaluation.py
+++ b/yaksh/evaluator_tests/test_java_evaluation.py
@@ -8,7 +8,7 @@ from yaksh.java_code_evaluator import JavaCodeEvaluator
 from yaksh.java_stdio_evaluator import JavaStdioEvaluator
 from yaksh.settings import SERVER_TIMEOUT
 from textwrap import dedent
-
+import subprocess
 
 class JavaAssertionEvaluationTestCases(unittest.TestCase):
     def setUp(self):
@@ -75,6 +75,7 @@ class JavaAssertionEvaluationTestCases(unittest.TestCase):
         result = get_class.evaluate(**kwargs) 
         self.assertFalse(result.get("success"))
         self.assertEqual(result.get("error"), self.timeout_msg)
+        self.assertEqual(1, subprocess.call(["pgrep", "java"]))
 
     def test_file_based_assert(self):
         self.file_paths = [("/tmp/test.txt", False)]
@@ -219,6 +220,7 @@ class JavaStdioEvaluationTestCases(unittest.TestCase):
         result = get_class.evaluate(**kwargs)
         self.assertFalse(result.get("success"))
         self.assertEqual(result.get("error"), self.timeout_msg)
+        self.assertEqual(1, subprocess.call(["pgrep", "java"]))
 
     def test_only_stdout(self):
         self.test_case_data = [{'expected_output': '11',

--- a/yaksh/evaluator_tests/test_scilab_evaluation.py
+++ b/yaksh/evaluator_tests/test_scilab_evaluation.py
@@ -7,6 +7,8 @@ import tempfile
 from yaksh import code_evaluator as evaluator
 from yaksh.scilab_code_evaluator import ScilabCodeEvaluator
 from yaksh.settings import SERVER_TIMEOUT
+import subprocess
+import time
 
 class ScilabEvaluationTestCases(unittest.TestCase):
     def setUp(self):
@@ -71,6 +73,8 @@ class ScilabEvaluationTestCases(unittest.TestCase):
         result = get_class.evaluate(**kwargs) 
         self.assertFalse(result.get("success"))
         self.assertEqual(result.get("error"), self.timeout_msg)
+        time.sleep(4)
+        self.assertEqual(1, subprocess.call(["pgrep", "scilab-cli-bin"]))
 
 if __name__ == '__main__':
     unittest.main()

--- a/yaksh/java_stdio_evaluator.py
+++ b/yaksh/java_stdio_evaluator.py
@@ -59,7 +59,8 @@ class JavaStdioEvaluator(StdIOEvaluator):
                                     shell=True,
                                     stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE
+                                    stderr=subprocess.PIPE,
+                                    preexec_fn=os.setpgrp
                                     )
             success, err = self.evaluate_stdio(user_answer, proc,
                                                expected_input,

--- a/yaksh/stdio_evaluator.py
+++ b/yaksh/stdio_evaluator.py
@@ -1,11 +1,8 @@
 from __future__ import unicode_literals
-
 # Local imports
-from .code_evaluator import CodeEvaluator
+from .code_evaluator import CodeEvaluator, TimeoutException
 import os
 import signal
-# Local imports
-from code_evaluator import CodeEvaluator, TimeoutException
 
 
 class StdIOEvaluator(CodeEvaluator):
@@ -21,11 +18,10 @@ class StdIOEvaluator(CodeEvaluator):
         success = False
         ip = expected_input.replace(",", " ")
         encoded_input = '{0}\n'.format(ip).encode('utf-8')
-        user_output_bytes, output_err_bytes = proc.communicate(encoded_input)
-        user_output = user_output_bytes.decode('utf-8')
-        output_err = output_err_bytes.decode('utf-8')
         try:
-            user_output, output_err = proc.communicate(input='{0}\n'.format(ip))
+            user_output_bytes, output_err_bytes = proc.communicate(encoded_input)
+            user_output = user_output_bytes.decode('utf-8')
+            output_err = output_err_bytes.decode('utf-8')
         except TimeoutException:
             os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
             raise

--- a/yaksh/stdio_evaluator.py
+++ b/yaksh/stdio_evaluator.py
@@ -2,6 +2,10 @@ from __future__ import unicode_literals
 
 # Local imports
 from .code_evaluator import CodeEvaluator
+import os
+import signal
+# Local imports
+from code_evaluator import CodeEvaluator, TimeoutException
 
 
 class StdIOEvaluator(CodeEvaluator):
@@ -20,6 +24,11 @@ class StdIOEvaluator(CodeEvaluator):
         user_output_bytes, output_err_bytes = proc.communicate(encoded_input)
         user_output = user_output_bytes.decode('utf-8')
         output_err = output_err_bytes.decode('utf-8')
+        try:
+            user_output, output_err = proc.communicate(input='{0}\n'.format(ip))
+        except TimeoutException:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            raise
         expected_output = expected_output.replace("\r", "")
         if not expected_input:
             error_msg = "Expected Output is {0} ".\

--- a/yaksh/templates/yaksh/grade_user.html
+++ b/yaksh/templates/yaksh/grade_user.html
@@ -148,7 +148,7 @@ Status : <b style="color: green;"> Passed </b><br/>
         </div>
     </div>
     {% if question.type == "mcq" or question.type == "mcc" %}
-        {% if "Correct answer" in answers.0.error %}
+        {% if answers.0.error %}
             <div class="panel panel-success">
         {% else %}
             <div class="panel panel-danger">

--- a/yaksh/templates/yaksh/monitor.html
+++ b/yaksh/templates/yaksh/monitor.html
@@ -1,4 +1,5 @@
 {% extends "manage.html" %}
+{% load custom_filters %}
 
 {% block title %} Quiz results {% endblock title %}
 
@@ -52,9 +53,19 @@ $(document).ready(function()
 {% if quiz %}
 
 {% if papers %}
-<p>Number of papers: {{ papers|length }} </p>
+<p>Number of papers: <b>{{ papers|length }} </b></p>
+
+{% completed papers as completed_papers %}
+{# template tag used to get the count of completed papers #}
+<p>Papers completed: <b> {{ completed_papers }} </b></p>
+
+{% inprogress papers as inprogress_papers %}
+{# template tag used to get the count of inprogress papers #}
+<p>Papers in progress:<b>  {{ inprogress_papers }} </b></p>
+
 <p><a href="{{URL_ROOT}}/exam/manage/statistics/question/{{papers.0.question_paper.id}}">Question Statisitics</a></p>
 <p><a href="{{URL_ROOT}}/exam/manage/monitor/download_csv/{{papers.0.question_paper.id}}">Download CSV</a></p>
+
 <table border="1" cellpadding="3"  id="result-table" class="tablesorter">
     <thead>
     <tr>

--- a/yaksh/templates/yaksh/user_data.html
+++ b/yaksh/templates/yaksh/user_data.html
@@ -83,7 +83,7 @@ User IP address: {{ paper.user_ip }}
         </div>
     </div>
     {% if question.type == "mcq" or question.type == "mcc" %}
-        {% if "Correct answer" in answers.0.error %}
+        {% if in answers.0 %}
             <div class="panel panel-success">
         {% else %}
             <div class="panel panel-danger">

--- a/yaksh/templates/yaksh/view_answerpaper.html
+++ b/yaksh/templates/yaksh/view_answerpaper.html
@@ -54,7 +54,7 @@
         </div>
     </div>
     {% if question.type == "mcq" or question.type == "mcc" %}
-        {% if "Correct answer" in answers.0.error %}
+        {% if answers.0.correct %}
             <div class="panel panel-success">
         {% else %}
             <div class="panel panel-danger">

--- a/yaksh/templatetags/custom_filters.py
+++ b/yaksh/templatetags/custom_filters.py
@@ -11,3 +11,11 @@ def escape_quotes(value):
 	escape_single_and_double_quotes = escape_single_quotes.replace('"', '\\"')
 
 	return escape_single_and_double_quotes
+
+@register.assignment_tag(name="completed")
+def completed(answerpaper):
+	return answerpaper.filter(status="completed").count()
+
+@register.assignment_tag(name="inprogress")
+def inprogress(answerpaper):
+	return answerpaper.filter(status="inprogress").count()


### PR DESCRIPTION
Minor bug fixes for -
1.  In both StdIO and assertion evaluators, whenever an infinite code was executed, the parent process (the terminal in this case) was killed but it spawned a child processes (the infinite code) which the code evaluator wouldn't kill/terminate. Fixed that bug.
2.  In view_answerpaper, grade user and user data, the bootstrap panels (the answer panels which indicated correct or incorrect answer) was decided using "correct answer" as a check. Changed it to  just check True or False conditions.
3.  Added no. of complete and inprogress papers for a quiz in monitor.
