### PR TITLE
Fixed output directory creation

### DIFF
--- a/yaksh/code_evaluator.py
+++ b/yaksh/code_evaluator.py
@@ -96,7 +96,7 @@ class CodeEvaluator(object):
     def setup(self):
         if self.in_dir:
             if not os.path.exists(self.in_dir):
-                os.mkdir(self.in_dir)
+                os.makedirs(self.in_dir)
         self._change_dir(self.in_dir)
 
     def safe_evaluate(self, user_answer, test_case_data, file_paths=None):

--- a/yaksh/code_evaluator.py
+++ b/yaksh/code_evaluator.py
@@ -94,6 +94,9 @@ class CodeEvaluator(object):
 
     # Private Protocol ##########
     def setup(self):
+        if self.in_dir:
+            if not os.path.exists(self.in_dir):
+                os.mkdir(self.in_dir)
         self._change_dir(self.in_dir)
 
     def safe_evaluate(self, user_answer, test_case_data, file_paths=None):

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -206,12 +206,6 @@ class Profile(models.Model):
         """Return the output directory for the user."""
 
         user_dir = join(settings.OUTPUT_DIR, str(self.user.username))
-        if not exists(user_dir):
-            os.makedirs(user_dir)
-            # Make it rwx by others.
-            os.chmod(user_dir, stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
-                     | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
-                     | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP)
         return user_dir
 
 
@@ -680,7 +674,7 @@ class QuestionPaper(models.Model):
 
     def create_demo_quiz_ppr(self, demo_quiz, user):
         question_paper = QuestionPaper.objects.create(quiz=demo_quiz,
-                                                      total_marks=5.0,
+                                                      total_marks=7.0,
                                                       shuffle_questions=True
                                                       )
         questions = Question.objects.filter(active=True,

--- a/yaksh/output/README.txt
+++ b/yaksh/output/README.txt
@@ -1,4 +1,0 @@
-This directory contains files generated/saved by users as per their
-username.  The test executor will chdir into this user directory for each
-user when they run the test.  Do not delete this directory and ensure that
-it is writeable by all.

--- a/yaksh/views.py
+++ b/yaksh/views.py
@@ -415,8 +415,6 @@ def start(request, questionpaper_id=None, attempt_num=None):
             msg = 'You do not have a profile and cannot take the quiz!'
             raise Http404(msg)
         new_paper = quest_paper.make_answerpaper(user, ip, attempt_num)
-        # Make user directory.
-        user_dir = new_paper.user.profile.get_user_dir()
         return show_question(request, new_paper.current_question(), new_paper)
 
 


### PR DESCRIPTION
Earlier User Output Directory was created from models.
Since `Code Evaluator` runs inside docker, this directory is not available for docker so it throws error for permission.
So now instead of creating directory from models it will be now created by `Code Evaluator` inside docker.