### PR TITLE
Fixed get_test_cases method

### DIFF
--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -317,17 +317,14 @@ class Question(models.Model):
 
     def get_test_cases(self, **kwargs):
         tc_list = []
-        for tc in self.testcase_set.all():
-            test_case_type = tc.type
+        for tc in self.testcase_set.values_list("type", flat=True).distinct():
             test_case_ctype = ContentType.objects.get(app_label="yaksh",
-                model=test_case_type
-            )
-            test_case = test_case_ctype.get_object_for_this_type(
+                                                      model=tc)
+            test_case = test_case_ctype.get_all_objects_for_this_type(
                 question=self,
                 **kwargs
             )
-            tc_list.append(test_case)
-
+            tc_list.extend(test_case)
         return tc_list
 
     def get_test_case(self, **kwargs):
@@ -1161,8 +1158,8 @@ class StandardTestCase(TestCase):
 
 
 class StdIOBasedTestCase(TestCase):
-    expected_input = models.CharField(max_length=100, blank=True)
-    expected_output = models.CharField(max_length=100)
+    expected_input = models.TextField(max_length=100, blank=True)
+    expected_output = models.TextField(max_length=100)
     weight = models.IntegerField(default=1.0)
 
     def get_field_value(self):
@@ -1172,9 +1169,9 @@ class StdIOBasedTestCase(TestCase):
                "weight": self.weight}
 
     def __str__(self):
-        return u'Question: {0} | Exp. Output: {1} | Exp. Input: {2}'.format(self.question,
-            self.expected_output, self.expected_input
-        )
+        return u'Question: {0} | Exp. Output: {1} | Exp. Input: {2}'\
+                .format(self.question, self.expected_output,
+                        self.expected_input)
 
 
 class McqTestCase(TestCase):


### PR DESCRIPTION
This PR contains the following fixes:
1. Previously, questions with multiple test cases of the same type would return a **MultipleObjectsReturn** Exception. Fixed the above mentioned bug.

2. Also, changed the Stdio Test cases model class attributes to be a **Textfield** instead if Charfield as it would not take newline entries in the form.
 