### PR TITLE
Fixed a bug which would mark all MCQ and MCC questions' answers as correct

### DIFF
--- a/yaksh/templates/yaksh/question.html
+++ b/yaksh/templates/yaksh/question.html
@@ -161,33 +161,11 @@ function call_skip(url)
                  </div>
                  <div class="panel-body">
                      {% if question.type == "mcq" %}
-                    {% if error_message %}
-                        <p>
-                        <div class="panel panel-danger">
-                        <div class="panel-heading">
-                        {% for err in error_message %}
-                            {{ err }}
-                        {% endfor %}
-                        </div>
-                        </div>
-                        </p>
-                     {% endif %}
                      {% for test_case in test_cases %}
                      <input name="answer" type="radio" value="{{ test_case.options }}" />{{ test_case.options|safe }} <br/>
                      {% endfor %}
                      {% endif %}
                      {% if question.type == "mcc" %}
-                    {% if error_message %}
-                        <p>
-                        <div class="panel panel-danger">
-                        <div class="panel-heading">
-                        {% for err in error_message %}
-                            {{ err }}
-                        {% endfor %}
-                        </div>
-                        </div>
-                        </p>
-                     {% endif %}
                      {% for test_case in test_cases %}
                      <input name="answer" type="checkbox" value="{{ test_case.options }}"> {{ test_case.options|safe }}
                      <br>

--- a/yaksh/test_models.py
+++ b/yaksh/test_models.py
@@ -533,22 +533,22 @@ class AnswerPaperTestCases(unittest.TestCase):
         )
         self.mcc_based_testcase.save()
 
-    def test_validate_and_regrade_mcc_question(self):
+    def test_validate_and_regrade_mcc_correct_answer(self):
         # Given
         mcc_answer = ['a']
         self.answer = Answer(question=self.question3,
-            answer=mcc_answer,
-        )
+                             answer=mcc_answer,
+                             )
         self.answer.save()
         self.answerpaper.answers.add(self.answer)
 
         # When
         json_data = None
-        correct, result = self.answerpaper.validate_answer(mcc_answer,
-                self.question3, json_data)
+        result = self.answerpaper.validate_answer(mcc_answer,
+                                                  self.question3, json_data
+                                                  )
 
         # Then
-        self.assertTrue(correct)
         self.assertTrue(result['success'])
         self.assertEqual(result['error'], ['Correct answer'])
         self.answer.correct = True
@@ -570,7 +570,7 @@ class AnswerPaperTestCases(unittest.TestCase):
         self.assertEqual(self.answer.marks, 0)
         self.assertFalse(self.answer.correct)
 
-    def test_validate_and_regrade_mcq_question(self):
+    def test_validate_and_regrade_mcq_correct_answer(self):
         # Given
         mcq_answer = 'a'
         self.answer = Answer(question=self.question2,
@@ -581,11 +581,11 @@ class AnswerPaperTestCases(unittest.TestCase):
 
         # When
         json_data = None
-        correct, result = self.answerpaper.validate_answer(mcq_answer,
-                self.question2, json_data)
+        result = self.answerpaper.validate_answer(mcq_answer,
+                                                  self.question2, json_data
+                                                  )
 
         # Then
-        self.assertTrue(correct)
         self.assertTrue(result['success'])
         self.answer.correct = True
         self.answer.marks = 1
@@ -606,6 +606,42 @@ class AnswerPaperTestCases(unittest.TestCase):
         self.assertEqual(self.answer.marks, 0)
         self.assertFalse(self.answer.correct)
 
+
+    def test_mcq_incorrect_answer(self):
+        # Given
+        mcq_answer = 'a'
+        self.answer = Answer(question=self.question2,
+            answer=mcq_answer,
+        )
+        self.answer.save()
+        self.answerpaper.answers.add(self.answer)
+
+        # When
+        json_data = None
+        result = self.answerpaper.validate_answer(mcq_answer,
+                                                  self.question2, json_data
+                                                  )
+
+        # Then
+        self.assertTrue(result['success'])
+
+    def test_mcc_incorrect_answer(self):
+        # Given
+        mcc_answer = ['b']
+        self.answer = Answer(question=self.question3,
+                             answer=mcc_answer,
+                             )
+        self.answer.save()
+        self.answerpaper.answers.add(self.answer)
+
+        # When
+        json_data = None
+        result = self.answerpaper.validate_answer(mcc_answer,
+                                                  self.question3, json_data
+                                                  )
+
+        # Then
+        self.assertFalse(result['success'])
 
     def test_answerpaper(self):
         """ Test Answer Paper"""

--- a/yaksh/views.py
+++ b/yaksh/views.py
@@ -488,12 +488,12 @@ def check(request, q_id, attempt_num=None, questionpaper_id=None):
         # safely in a separate process (the code_server.py) running as nobody.
         json_data = current_question.consolidate_answer_data(user_answer) \
                         if current_question.type == 'code' else None
-        correct, result = paper.validate_answer(user_answer, current_question, json_data)
-        if correct or result.get('success'):
+        result = paper.validate_answer(user_answer, current_question, json_data)
+        if result.get('success'):
             new_answer.marks = (current_question.points * result['weight'] / 
                 current_question.get_maximum_test_case_weight()) \
                 if current_question.partial_grading and current_question.type == 'code' else current_question.points
-            new_answer.correct = correct
+            new_answer.correct = result.get('success')
             error_message = None
             new_answer.error = json.dumps(result.get('error'))
             next_question = paper.completed_question(current_question.id)


### PR DESCRIPTION
1. Due to the new evaluator, an unchecked bug, which marked all mcq and mcc attempts as correct, despite actually marking the wrong answer, has been fixed.
2. Added Test case to check for incorrect mcq and mcc questions
3. question.html would also render error msg for mcq and mcc questions. This has also been fixed.