### PR TITLE
removed none type in answerpaper generation

### DIFF
--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -954,10 +954,10 @@ class AnswerPaper(models.Model):
     comments = models.TextField()
 
     # Total marks earned by the student in this paper.
-    marks_obtained = models.FloatField(null=True, default=None)
+    marks_obtained = models.FloatField(null=True, default=0.0)
 
     # Marks percent scored by the user
-    percent = models.FloatField(null=True, default=None)
+    percent = models.FloatField(null=True, default=0.0)
 
     # Result of the quiz, True if student passes the exam.
     passed = models.NullBooleanField()


### PR DESCRIPTION
Minor changes in the model. Every time a new answer paper is created, the marks assigned to that paper would be None. Fixed this. Now the default marks during the creation of the answer paper is 0.0 