### PR TITLE
Ordering Questions while creating Question Paper

### DIFF
--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -635,10 +635,8 @@ class QuestionPaperManager(models.Manager):
             trial_questionpaper = self.create(quiz=trial_quiz,
                                               total_marks=10,
                                               )
-            for q_id in questions_list:
-                que = Question.objects.get(id=q_id)
-                FixedQuestions.objects.add_fixed_questions(
-                    trial_questionpaper, que)
+            trial_questionpaper.fixed_question_order = ",".join(questions_list)
+            trial_questionpaper.fixed_questions.add(*questions_list)
             return trial_questionpaper
 
     def create_trial_paper_to_test_quiz(self, trial_quiz, original_quiz_id):
@@ -647,8 +645,7 @@ class QuestionPaperManager(models.Manager):
             trial_questionpaper = self.get(quiz=trial_quiz)
         else:
             trial_questionpaper, trial_questions = \
-                self._create_trial_from_questionpaper(original_quiz_id,
-                )
+                self._create_trial_from_questionpaper(original_quiz_id)
             trial_questionpaper.quiz = trial_quiz
             trial_questionpaper.fixed_questions\
                 .add(*trial_questions["fixed_questions"])
@@ -757,7 +754,7 @@ class QuestionPaper(models.Model):
                                             summary="Yaksh Demo Question",
                                             user=user)
         q_order = [str(que.id) for que in questions]
-        question_paper.fixed_questions_order = ",".join(q_order)
+        question_paper.fixed_question_order = ",".join(q_order)
         question_paper.save()
         # add fixed set of questions to the question paper
         question_paper.fixed_questions.add(*questions)

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -765,6 +765,8 @@ class QuestionPaper(models.Model):
             que_order = self.fixed_question_order.split(',')
             for que_id in que_order:
                 ques.append(self.fixed_questions.get(id=que_id))
+        else:
+            ques = self.fixed_questions.all()
         return ques
 
     def __str__(self):

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -756,6 +756,9 @@ class QuestionPaper(models.Model):
         questions = Question.objects.filter(active=True,
                                             summary="Yaksh Demo Question",
                                             user=user)
+        q_order = [str(que.id) for que in questions]
+        question_paper.fixed_questions_order = ",".join(q_order)
+        question_paper.save()
         # add fixed set of questions to the question paper
         question_paper.fixed_questions.add(*questions)
 

--- a/yaksh/static/yaksh/js/question_paper_creation.js
+++ b/yaksh/static/yaksh/js/question_paper_creation.js
@@ -46,4 +46,18 @@ $(document).ready(function(){
         $("#random").click();
     });
 
+    var checked_vals = [];
+    $('input:checkbox[name="questions"]').click(function() {
+        if($(this).prop("checked") == true){
+            checked_vals.push(parseInt($(this).val()));
+        }
+        else{
+            checked_vals.pop(parseInt($(this).val()));
+        }
+    });
+    $('#design_q').submit(function(eventObj) {
+        $(this).append('<input type="hidden" name="checked_ques" value='+checked_vals+'>');
+        return true;
+});
+
 });//document

--- a/yaksh/templates/yaksh/design_questionpaper.html
+++ b/yaksh/templates/yaksh/design_questionpaper.html
@@ -23,7 +23,7 @@ select
 
 {% block content %}
 <input type=hidden id="url_root" value={{ URL_ROOT }}>
-<form action="{{ URL_ROOT }}/exam/manage/designquestionpaper/{{ qpaper.quiz.id }}/{{ qpaper.id }}/" method="POST">
+<form action="{{ URL_ROOT }}/exam/manage/designquestionpaper/{{ qpaper.quiz.id }}/{{ qpaper.id }}/" method="POST" id="design_q">
 <input class ="btn primary small" type="submit" name="back" id="back" value="Cancel">
     {% csrf_token %}
     <input type=hidden name="is_active" id="is_active" value="{{ state }}">
@@ -95,8 +95,10 @@ select
                                {% for question in fixed_questions %}
                                     <li>
                                         <label>
-                                            <input type="checkbox" name="added-questions" data-qid="{{question.id}}" value={{question.id}}>
-                                            <span> {{ question.summary }} </span> <span> {{ question.points }} </span>
+                                            <input type="checkbox" name="added-questions"
+                                            data-qid="{{question.id}}" value={{question.id}}>
+                                            <span> {{ question.summary }} </span>
+                                            <span> {{ question.points }} </span>
                                         </label>
                                      </li>
                                 {% endfor %}

--- a/yaksh/test_models.py
+++ b/yaksh/test_models.py
@@ -1,7 +1,7 @@
 import unittest
 from yaksh.models import User, Profile, Question, Quiz, QuestionPaper,\
     QuestionSet, AnswerPaper, Answer, Course, StandardTestCase,\
-    StdIOBasedTestCase, FileUpload, McqTestCases
+    StdIOBasedTestCase, FileUpload, McqTestCase
 import json
 from datetime import datetime, timedelta
 from django.utils import timezone
@@ -324,6 +324,9 @@ class QuestionPaperTestCases(unittest.TestCase):
             shuffle_questions=True
         )
 
+        self.question_paper.fixed_question_order = "{0}, {1}".format(
+                self.questions[3].id, self.questions[5].id
+                )
         # add fixed set of questions to the question paper
         self.question_paper.fixed_questions.add(self.questions[3],
                 self.questions[5]
@@ -417,7 +420,6 @@ class QuestionPaperTestCases(unittest.TestCase):
                                                              attempt_num)
         self.assertIsInstance(answerpaper, AnswerPaper)
         paper_questions = answerpaper.questions.all()
-        print (paper_questions)
         self.assertEqual(len(paper_questions), 7)
         fixed_questions = set(self.question_paper.fixed_questions.all())
         self.assertTrue(fixed_questions.issubset(set(paper_questions)))
@@ -449,6 +451,11 @@ class QuestionPaperTestCases(unittest.TestCase):
             fixed_q = self.question_paper.fixed_questions.values_list(
                 'id', flat=True)
             self.assertEqual(self.questions_list, fixed_q)
+
+    def test_fixed_order_questions(self):
+        fixed_ques = self.question_paper.get_ordered_questions()
+        actual_ques = [self.questions[3], self.questions[5]]
+        self.assertSequenceEqual(fixed_ques, actual_ques)
 
 
 ###############################################################################

--- a/yaksh/test_models.py
+++ b/yaksh/test_models.py
@@ -1,7 +1,7 @@
 import unittest
 from yaksh.models import User, Profile, Question, Quiz, QuestionPaper,\
     QuestionSet, AnswerPaper, Answer, Course, StandardTestCase,\
-    StdIOBasedTestCase, FileUpload, McqTestCase, FixedQuestions
+    StdIOBasedTestCase, FileUpload, McqTestCases
 import json
 from datetime import datetime, timedelta
 from django.utils import timezone
@@ -325,9 +325,9 @@ class QuestionPaperTestCases(unittest.TestCase):
         )
 
         # add fixed set of questions to the question paper
-        fixed_ques = FixedQuestions()
-        fixed_ques.add_fixed_questions(self.question_paper, self.questions[3])
-        fixed_ques.add_fixed_questions(self.question_paper, self.questions[5])
+        self.question_paper.fixed_questions.add(self.questions[3],
+                self.questions[5]
+                )
 
         # create two QuestionSet for random questions
         # QuestionSet 1
@@ -376,9 +376,9 @@ class QuestionPaperTestCases(unittest.TestCase):
     def test_questionpaper(self):
         """ Test question paper"""
         self.assertEqual(self.question_paper.quiz.description, 'demo quiz')
-        fixed_ques = FixedQuestions()
-        ques = fixed_ques.get_fixed_questions(self.question_paper)
-        self.assertSequenceEqual(ques, [self.questions[3], self.questions[5]])
+        self.assertSequenceEqual(self.question_paper.fixed_questions.all(),
+                [self.questions[3], self.questions[5]]
+                )
         self.assertTrue(self.question_paper.shuffle_questions)
 
     def test_update_total_marks(self):
@@ -417,9 +417,9 @@ class QuestionPaperTestCases(unittest.TestCase):
                                                              attempt_num)
         self.assertIsInstance(answerpaper, AnswerPaper)
         paper_questions = answerpaper.questions.all()
+        print (paper_questions)
         self.assertEqual(len(paper_questions), 7)
-        fixed_ques = FixedQuestions()
-        fixed_questions = set(fixed_ques.get_fixed_questions(self.question_paper))
+        fixed_questions = set(self.question_paper.fixed_questions.all())
         self.assertTrue(fixed_questions.issubset(set(paper_questions)))
         answerpaper.passed = True
         answerpaper.save()
@@ -433,8 +433,8 @@ class QuestionPaperTestCases(unittest.TestCase):
                                                  self.question_paper.id
                                                  )
             self.assertEqual(trial_paper.quiz, trial_quiz)
-            self.assertEqual(fixed_ques.get_fixed_questions(trial_paper),
-                             fixed_ques.get_fixed_questions(self.question_paper)
+            self.assertEqual(trial_paper.fixed_questions.all(),
+                             self.question_paper.fixed_questions.all()
                              )
             self.assertEqual(trial_paper.random_questions.all(),
                              self.question_paper.random_questions.all()
@@ -446,9 +446,8 @@ class QuestionPaperTestCases(unittest.TestCase):
                                     trial_quiz, self.questions_list
                                     )
             self.assertEqual(trial_paper.quiz, trial_quiz)
-            fixed_q = FixedQuestions.objects.filter(
-                questionpaper=self.question_paper).values_list(
-                'question_id', flat=True)
+            fixed_q = self.question_paper.fixed_questions.values_list(
+                'id', flat=True)
             self.assertEqual(self.questions_list, fixed_q)
 
 

--- a/yaksh/test_views.py
+++ b/yaksh/test_views.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 from yaksh.models import User, Profile, Question, Quiz, QuestionPaper,\
     QuestionSet, AnswerPaper, Answer, Course, StandardTestCase,\
-    StdIOBasedTestCase, has_profile
+    StdIOBasedTestCase, has_profile, FixedQuestions
 
 
 class TestProfile(TestCase):
@@ -1161,8 +1161,8 @@ class TestViewAnswerPaper(TestCase):
 
         self.question_paper = QuestionPaper.objects.create(quiz=self.quiz,
             total_marks=1.0)
-
-        self.question_paper.fixed_questions.add(self.question)
+        fixed_ques = FixedQuestions()
+        fixed_ques.add_fixed_questions(self.question_paper, self.question)
         self.question_paper.save()
 
         AnswerPaper.objects.create(user_id=3,
@@ -1446,8 +1446,8 @@ class TestGrader(TestCase):
 
         self.question_paper = QuestionPaper.objects.create(quiz=self.quiz,
             total_marks=1.0)
-
-        self.question_paper.fixed_questions.add(self.question)
+        fixed_ques = FixedQuestions()
+        fixed_ques.add_fixed_questions(self.question_paper, self.question)
         self.question_paper.save()
 
         self.answerpaper = AnswerPaper.objects.create(user_id=3,

--- a/yaksh/test_views.py
+++ b/yaksh/test_views.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 from yaksh.models import User, Profile, Question, Quiz, QuestionPaper,\
     QuestionSet, AnswerPaper, Answer, Course, StandardTestCase,\
-    StdIOBasedTestCase, has_profile, FixedQuestions
+    StdIOBasedTestCase, has_profile
 
 
 class TestProfile(TestCase):
@@ -1161,8 +1161,7 @@ class TestViewAnswerPaper(TestCase):
 
         self.question_paper = QuestionPaper.objects.create(quiz=self.quiz,
             total_marks=1.0)
-        fixed_ques = FixedQuestions()
-        fixed_ques.add_fixed_questions(self.question_paper, self.question)
+        self.question_paper.fixed_questions.add(self.question)
         self.question_paper.save()
 
         AnswerPaper.objects.create(user_id=3,
@@ -1446,8 +1445,7 @@ class TestGrader(TestCase):
 
         self.question_paper = QuestionPaper.objects.create(quiz=self.quiz,
             total_marks=1.0)
-        fixed_ques = FixedQuestions()
-        fixed_ques.add_fixed_questions(self.question_paper, self.question)
+        self.question_paper.fixed_questions.add(self.question)
         self.question_paper.save()
 
         self.answerpaper = AnswerPaper.objects.create(user_id=3,

--- a/yaksh/views.py
+++ b/yaksh/views.py
@@ -25,7 +25,8 @@ import six
 # Local imports.
 from yaksh.models import get_model_class, Quiz, Question, QuestionPaper, QuestionSet, Course
 from yaksh.models import Profile, Answer, AnswerPaper, User, TestCase, FileUpload,\
-                        has_profile, StandardTestCase, McqTestCase, StdIOBasedTestCase, HookTestCase
+                        has_profile, StandardTestCase, McqTestCase, StdIOBasedTestCase, HookTestCase,\
+                        FixedQuestions
 from yaksh.forms import UserRegisterForm, UserLoginForm, QuizForm,\
                 QuestionForm, RandomQuestionForm,\
                 QuestionFilterForm, CourseForm, ProfileForm, UploadFileForm,\
@@ -265,7 +266,8 @@ def show_all_questionpapers(request, questionpaper_id=None):
     else:
         qu_papers = QuestionPaper.objects.get(id=questionpaper_id)
         quiz = qu_papers.quiz
-        fixed_questions = qu_papers.fixed_questions.all()
+        fixed_ques = FixedQuestions()
+        fixed_questions = fixed_ques.get_fixed_questions(qu_papers)
         random_questions = qu_papers.random_questions.all()
         context = {'quiz': quiz, 'fixed_questions': fixed_questions,
                    'random_questions': random_questions}
@@ -805,8 +807,9 @@ def _remove_already_present(questionpaper_id, questions):
     if questionpaper_id is None:
         return questions
     questionpaper = QuestionPaper.objects.get(pk=questionpaper_id)
-    questions = questions.exclude(
-            id__in=questionpaper.fixed_questions.values_list('id', flat=True))
+    fixed_questions = FixedQuestions.objects.filter(
+        questionpaper=questionpaper).values_list('question_id', flat=True)
+    questions = questions.exclude(id__in=fixed_questions)
     for random_set in questionpaper.random_questions.all():
         questions = questions.exclude(
                 id__in=random_set.questions.values_list('id', flat=True))
@@ -824,6 +827,7 @@ def design_questionpaper(request, quiz_id, questionpaper_id=None):
     questions = None
     marks = None
     state = None
+    fixed_que = FixedQuestions()
     if questionpaper_id is None:
         question_paper = QuestionPaper.objects.get_or_create(quiz_id=quiz_id)[0]
     else:
@@ -839,13 +843,14 @@ def design_questionpaper(request, quiz_id, questionpaper_id=None):
         state = request.POST.get('is_active', None)
 
         if 'add-fixed' in request.POST:
-            question_ids = request.POST.getlist('questions', None)
-            for question in Question.objects.filter(id__in=question_ids):
-                question_paper.fixed_questions.add(question)
+            question_ids = request.POST.get('checked_ques', None).split(',')
+            for q_id in question_ids:
+                que = Question.objects.get(id=q_id)
+                fixed_que.add_fixed_questions(question_paper, que)
 
         if 'remove-fixed' in request.POST:
             question_ids = request.POST.getlist('added-questions', None)
-            question_paper.fixed_questions.remove(*question_ids)
+            fixed_que.remove_fixed_questions(question_ids)
 
         if 'add-random' in request.POST:
             question_ids = request.POST.getlist('random_questions', None)
@@ -872,7 +877,7 @@ def design_questionpaper(request, quiz_id, questionpaper_id=None):
         question_paper.update_total_marks()
         question_paper.save()
     random_sets = question_paper.random_questions.all()
-    fixed_questions = question_paper.fixed_questions.all()
+    fixed_questions = fixed_que.get_fixed_questions(question_paper)
     context = {'qpaper_form': qpaper_form, 'filter_form': filter_form, 'qpaper':
             question_paper, 'questions': questions, 'fixed_questions': fixed_questions,
             'state': state, 'random_sets': random_sets}


### PR DESCRIPTION
This PR will add questions to Question Paper in the order of selection.
The Questions while displaying will not order by key and will show up according to selections made during creation of question paper.
This fixes issue #213 