### PR TITLE
Adds tabbed view for error output

### DIFF
--- a/yaksh/static/yaksh/css/exam.css
+++ b/yaksh/static/yaksh/css/exam.css
@@ -2,6 +2,6 @@ table td, table th { border: black solid 1px !important;
 			word-wrap: break-word !important;
 			white-space: pre-wrap !important;
 			}
-output{
-	table-layout: fixed
+#output{
+	table-layout: fixed !important;
 }

--- a/yaksh/templates/exam.html
+++ b/yaksh/templates/exam.html
@@ -86,7 +86,7 @@
       </a></li>
 {% endfor %}
 </ul>
-
+<br/>
       <div class="tab-content">
       {% for error in error_message %}
       <div id="error_{{ forloop.counter }}" class="tab-pane fade">

--- a/yaksh/templates/exam.html
+++ b/yaksh/templates/exam.html
@@ -77,9 +77,21 @@
             {% if question.type == 'code' or question.type == 'upload' %}
                 {% if error_message %}
                     <div class="row" id="error_panel">
+
+<br/>
+<ul class="nav nav-pills">
+{% for error in error_message %}
+      <li><a data-toggle="pill" href="#error_{{ forloop.counter }}">
+        Testcase no. {{forloop.counter}}
+      </a></li>
+{% endfor %}
+</ul>
+
+      <div class="tab-content">
       {% for error in error_message %}
-              <div class="panel panel-danger">
-      <div class="panel-heading">Testcase No. {{ forloop.counter }}</div>
+      <div id="error_{{ forloop.counter }}" class="tab-pane fade">
+      <div class = 'panel panel-danger'>
+      <div class="panel-heading">Error!</div>
       <div class="panel-body">
       <div class="well well-sm">
       {% if not error.expected_output %}
@@ -124,16 +136,16 @@
            <td>{{error.error_msg}}</td>
            </tr>
           </table>
-        
-        {% endif %}
-        </div>
+      {% endif %}
+      </div>
+      </div>
       </div>
       </div>
       {% endfor %}
-
-                    </div>
-                {% endif %}
-            {% endif %}
+      </div>
+</div>
+{% endif %}
+{% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Adds tabbed view of error output for testcases during exam, instead of a long list of error output for each testcase.
- Fixes word wrap issue with stdIO error output
![peek 2017-06-22 01-51](https://user-images.githubusercontent.com/10505209/27405082-d89f5b54-56ed-11e7-9ebc-b9bab3c690d3.gif)
