### PR TITLE
Installs Firefox v46.0 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ script:
 after_success:
   - coverage combine
   - coverage report
+
+addons:
+  firefox: "46.0"


### PR DESCRIPTION
Selenium v2.53.6 seems to work perfectly with Firefox v46.0. Travis CI is expected to keep upgrading their default linux distribution, which might not have Firefox v46.0 in it's repository. Hence we enforce Travis CI to install Firefox v46.0. 