### PR TITLE
Yaml fixes

### DIFF
--- a/yaksh/evaluator_tests/test_bash_evaluation.py
+++ b/yaksh/evaluator_tests/test_bash_evaluation.py
@@ -255,7 +255,6 @@ class BashStdIOEvaluationTestCases(EvaluatorBaseTest):
                              """
                              )
         test_case_data = [{'expected_output': '10',
-                           'expected_input': '',
                            'test_case_type': 'stdiobasedtestcase',
                            'weight': 0.0
                            }]

--- a/yaksh/evaluator_tests/test_c_cpp_evaluation.py
+++ b/yaksh/evaluator_tests/test_c_cpp_evaluation.py
@@ -415,7 +415,6 @@ class CppStdIOEvaluationTestCases(EvaluatorBaseTest):
     def test_only_stdout(self):
         # Given
         self.test_case_data = [{'expected_output': '11',
-                               'expected_input': '',
                                 'weight': 0.0,
                                 'test_case_type': 'stdiobasedtestcase',
                                 }]

--- a/yaksh/evaluator_tests/test_java_evaluation.py
+++ b/yaksh/evaluator_tests/test_java_evaluation.py
@@ -414,7 +414,6 @@ class JavaStdIOEvaluationTestCases(EvaluatorBaseTest):
     def test_only_stdout(self):
         # Given
         self.test_case_data = [{'expected_output': '11',
-                                'expected_input': '',
                                 'test_case_type': 'stdiobasedtestcase',
                                 'weight': 0.0
                                }]

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -925,7 +925,6 @@ class QuestionPaper(models.Model):
 
     def create_demo_quiz_ppr(self, demo_quiz, user):
         question_paper = QuestionPaper.objects.create(quiz=demo_quiz,
-                                                      total_marks=6.0,
                                                       shuffle_questions=False
                                                       )
         summaries = ['Roots of quadratic equation', 'Print Output',
@@ -941,6 +940,8 @@ class QuestionPaper(models.Model):
         question_paper.save()
         # add fixed set of questions to the question paper
         question_paper.fixed_questions.add(*questions)
+        question_paper.update_total_marks()
+        question_paper.save()
 
     def get_ordered_questions(self):
         ques = []

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -420,9 +420,11 @@ class Question(models.Model):
             msg = "Questions Uploaded Successfully"
             for question in questions:
                 question['user'] = user
-                file_names = question.pop('files')
+                file_names = question.pop('files') \
+                             if 'files' in question \
+                             else None
+                tags = question.pop('tags') if 'tags' in question else None
                 test_cases = question.pop('testcase')
-                tags = question.pop('tags')
                 que, result = Question.objects.get_or_create(**question)
                 if file_names:
                     que._add_files_to_db(file_names, file_path)

--- a/yaksh/stdio_evaluator.py
+++ b/yaksh/stdio_evaluator.py
@@ -11,10 +11,15 @@ from .compare_stdio import compare_outputs
 class StdIOEvaluator(BaseEvaluator):
     def evaluate_stdio(self, user_answer, proc, expected_input, expected_output):
         success = False
-        ip = expected_input.replace(",", " ")
-        encoded_input = '{0}\n'.format(ip).encode('utf-8')
         try:
-            user_output_bytes, output_err_bytes = proc.communicate(encoded_input)
+            if expected_input:
+                ip = expected_input.replace(",", " ")
+                encoded_input = '{0}\n'.format(ip).encode('utf-8')
+                user_output_bytes, output_err_bytes = proc.communicate(
+                                                           encoded_input
+                                                           )
+            else:
+                user_output_bytes, output_err_bytes = proc.communicate()
             user_output = user_output_bytes.decode('utf-8')
             output_err = output_err_bytes.decode('utf-8')
         except TimeoutException:

--- a/yaksh/templates/yaksh/question.html
+++ b/yaksh/templates/yaksh/question.html
@@ -184,11 +184,11 @@ lang = "{{ question.language }}"
                      {% if question.type == "mcc" %}
                      {% for test_case in test_cases %}
                      {% if last_attempt and test_case.id|safe in last_attempt|safe %}
-                     <input name="answer" type="checkbox" value="{{ test_case.id }}" checked/> {{ test_case.options }}
+                     <input name="answer" type="checkbox" value="{{ test_case.id }}" checked/> {{ test_case.options| safe }}
                      <br>
                      {% else %}
                      <input name="answer" type="checkbox" value="{{ test_case.id }}">
-                     {{ test_case.options}}
+                     {{ test_case.options| safe }}
                      <br/>
                      {% endif %}
                      {% endfor %}

--- a/yaksh/templates/yaksh/showquestions.html
+++ b/yaksh/templates/yaksh/showquestions.html
@@ -18,7 +18,7 @@
       <li><a href="#updown" data-toggle="pill" > Upload and Download Questions</a></li>
       </ul>
     </div>
-<div class="tab-content">
+<div class="tab-content col-md-9 col-md-offset-2 main">
 <!-- Upload Questions -->
 <div id="updown" class="tab-pane fade">
 <a class="btn btn-primary" href="{{URL_ROOT}}/exam/manage/courses/download_yaml_template/"> Download Template</a>

--- a/yaksh/templates/yaksh/user_data.html
+++ b/yaksh/templates/yaksh/user_data.html
@@ -78,7 +78,8 @@ User IP address: {{ paper.user_ip }}
                         {% endif %}
                     {% endfor %}
 
-            {% elif question.type == "integer" or "string" or "float" %}
+            {% elif question.type == "integer" or question.type == "string"
+               or question.type == "float" %}
                 <h5> <u>Correct Answer:</u></h5>
                     {% for testcase in question.get_test_cases %}
                     <strong>{{ testcase.correct|safe }}</strong>
@@ -96,15 +97,14 @@ User IP address: {{ paper.user_ip }}
     {% if question.type != "code" %}
         {% if "Correct answer" in answers.0.error_list %}
             <div class="panel panel-success">
+            <div class="panel-heading"><strong>Correct</strong></div>
         {% else %}
             <div class="panel panel-danger">
+            <div class="panel-heading"><strong> Incorrect</strong></div>
         {% endif %}
-            <div class="panel-heading">
-                Autocheck: {{ answers.0.error_list.0 }}
-            </div>
             <div class="panel-body">
                 <h5><u>Student answer:</u></h5>
-                {% if question.type == "mcc"%}
+        {% if question.type == "mcc"%}
         <div class="well well-sm">
         {% for testcases in question.get_test_cases %}
         {%if testcases.id|stringformat:"i" in answers.0.answer|safe %}
@@ -124,9 +124,9 @@ User IP address: {{ paper.user_ip }}
                  <div class="well well-sm">
                  {{ answers.0.answer|safe }}
                  </div>
-            </div>
-            </div>
         {% endif %}
+            </div>
+        </div>
     {% else %}
     <h5>Student answer: </h5>
     {% for answer in answers %}

--- a/yaksh/templates/yaksh/view_answerpaper.html
+++ b/yaksh/templates/yaksh/view_answerpaper.html
@@ -79,7 +79,7 @@
             <div class="panel panel-danger">
         {% endif %}
             <div class="panel-heading">
-                Autocheck: {{ answers.0.error_list.0 }}
+                <strong>{{ answers.0.error_list.0 }}</strong>
             </div>
             <div class="panel-body">
             {% if question.type == "mcc"%}
@@ -117,12 +117,18 @@
     <h5>Student answer: </h5>
     {% for answer in answers %}
     {% if not answer.skipped %}
-    {% if "Correct answer" in answer.error %}
+    {% if answer.answer.correct %}
             <div class="panel panel-success">
+            <div class="panel-heading">
+            <strong>Correct Answer</strong>
+            </div>
         {% else %}
             <div class="panel panel-danger">
+            <div class="panel-heading">
+              <strong>Incorrect Answer</strong>
+            </div>
         {% endif %}
-    <div class="panel-heading">Error:</div>
+    
         {% with answer.error_list as err %}
             {% for error in err %}
             {% if not error.expected_output %}


### PR DESCRIPTION
The PR contains the following fixes:

1. Can skip adding file and/or tags field in Yaml question file with test cases. Closes #338 
2. The sidebar on show questions page doesnt overlap on the question list.
3. All questions in view answerpaper accurately display the answer panel heading.  
4. Marks MCC options as  html-safe.
5. Fixes bug where C/C++, Java, and bash wouldn't work with Expected input as None with test case.
6. Fixes user data bug. Closes #357 