### PR TITLE
Edit Profile Bug Fix

### DIFF
--- a/yaksh/test_views.py
+++ b/yaksh/test_views.py
@@ -196,6 +196,38 @@ class TestProfile(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'yaksh/profile_updated.html')
 
+    def test_edit_profile_post_for_user_without_profile(self):
+        """
+        POST request to edit_profile view should update the user's profile
+        """
+        self.client.login(
+            username=self.user1.username,
+            password=self.user1_plaintext_pass
+        )
+        response = self.client.post(reverse('yaksh:edit_profile'),
+            data={
+                'user': self.user1,
+                'first_name': 'new_first_name',
+                'last_name': 'new_last_name',
+                'roll_number': 21,
+                'institute': 'new_institute',
+                'department': 'Aerospace',
+                'position': 'new_position',
+                'timezone': 'UTC'
+            }
+        )
+        updated_profile_user = User.objects.get(id=self.user1.id)
+        updated_profile = Profile.objects.get(user=updated_profile_user)
+        self.assertEqual(updated_profile_user.first_name, 'new_first_name')
+        self.assertEqual(updated_profile_user.last_name, 'new_last_name')
+        self.assertEqual(updated_profile.roll_number, '21')
+        self.assertEqual(updated_profile.institute, 'new_institute')
+        self.assertEqual(updated_profile.department, 'Aerospace')
+        self.assertEqual(updated_profile.position, 'new_position')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'yaksh/profile_updated.html')
+
     def test_edit_profile_get(self):
         """
         GET request to edit profile should display profile form

--- a/yaksh/views.py
+++ b/yaksh/views.py
@@ -1406,7 +1406,6 @@ def view_profile(request):
 
 
 @login_required
-@has_profile
 @email_verified
 def edit_profile(request):
     """ edit profile details facility for moderator and students """
@@ -1418,7 +1417,10 @@ def edit_profile(request):
     else:
         template = 'user.html'
     context = {'template': template}
-    profile = Profile.objects.get(user_id=user.id)
+    try:
+        profile = Profile.objects.get(user_id=user.id)
+    except Profile.DoesNotExist:
+        profile = None
 
     if request.method == 'POST':
         form = ProfileForm(request.POST, user=user, instance=profile)


### PR DESCRIPTION
edit_profile view had a decorator has_profile.
So, has_profile will redirect to edit_profile if no profile.
But then if I submit my profile form then the has_profile will again
redirect to edit_profile, instead of updating my profile.
So this cycle will continue endlessly for a user with no profile, and
will never be able to create/update his profile!

Will face this when user is created via csv upload, django admin or
oauth login without pipeline.

Also, profile instance is passed to the profile form via get query,
which will fail if no profile.

Added a views test for the above.
Fixed. Closes #374 

Additionally that can be thought of later:
The has_profile decorator is used for few views only,
so one can access views if they know the url, even if they do not have a
profile.
email edit option for users