### PR TITLE
Change travis build distribution from precise to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,11 @@ after_success:
   - coverage report
   - codecov
 
+sudo:
+    required
+
 dist:
-    precise
+    trusty
 
 addons:
   firefox: "46.0"


### PR DESCRIPTION
- Travis is going to decommission Precise distribution. Travis recommends to update distribution to trusty
