### PR TITLE
Specify tornado version to 4.5.3

### DIFF
--- a/requirements/requirements-codeserver.txt
+++ b/requirements/requirements-codeserver.txt
@@ -2,5 +2,5 @@ pytest
 python-decouple
 six
 requests
-tornado
+tornado==4.5.3
 psutil


### PR DESCRIPTION
1. The newer version of Tornado i.e v5.0.0 causes the current suite of code server tests to fail. Reverting the tornado version to 4.5.3. 
