### PR TITLE
Add -lm to the link flags for math functions

### DIFF
--- a/yaksh/cpp_code_evaluator.py
+++ b/yaksh/cpp_code_evaluator.py
@@ -51,9 +51,9 @@ class CppCodeEvaluator(BaseEvaluator):
 
     def get_commands(self, clean_ref_code_path, user_output_path,
                      ref_output_path):
-        compile_command = 'g++ {0} -c -o {1} -lm -lblas -llapack'.format(
+        compile_command = 'gcc {0} -c -o {1} -lm -lblas -llapack'.format(
             self.submit_code_path, user_output_path)
-        compile_main = 'g++ {0} {1} -o {2} -lm -lblas -llapack'.format(
+        compile_main = 'gcc {0} {1} -o {2} -lm -lblas -llapack'.format(
             clean_ref_code_path, user_output_path,
             ref_output_path
             )

--- a/yaksh/cpp_stdio_evaluator.py
+++ b/yaksh/cpp_stdio_evaluator.py
@@ -41,9 +41,9 @@ class CppStdIOEvaluator(StdIOEvaluator):
         return user_output_path, ref_output_path
 
     def get_commands(self, user_output_path, ref_output_path):
-        compile_command = 'g++  {0} -c -o {1} -lm -lblas -llapack'.format(self.submit_code_path,
+        compile_command = 'gcc  {0} -c -o {1} -lm -lblas -llapack'.format(self.submit_code_path,
                                                       user_output_path)
-        compile_main = 'g++ {0} -o {1} -lm -lblas -llapack'.format(user_output_path,
+        compile_main = 'gcc {0} -o {1} -lm -lblas -llapack'.format(user_output_path,
                                                ref_output_path)
         return compile_command, compile_main
 


### PR DESCRIPTION
Some math functions like fabs are optimized by gcc, and these don't
require linking against libm.so. However, for most common functions
such as sqrt, we need to link against libm.so. This commit adds the -lm
flag to enable this.