### PR TITLE
 Allow student to open a quiz if status is inprogress

### DIFF
--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -1600,7 +1600,9 @@ class QuestionPaper(models.Model):
         attempts = AnswerPaper.objects.get_total_attempt(questionpaper=self,
                                                          user=user,
                                                          course_id=course_id)
-        return attempts < self.quiz.attempts_allowed or self.quiz.attempts_allowed == -1
+        attempts_allowed = attempts < self.quiz.attempts_allowed
+        infinite_attempts = self.quiz.attempts_allowed == -1
+        return attempts_allowed or infinite_attempts
 
     def can_attempt_now(self, user, course_id):
         if self._is_attempt_allowed(user, course_id):

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -1600,7 +1600,7 @@ class QuestionPaper(models.Model):
         attempts = AnswerPaper.objects.get_total_attempt(questionpaper=self,
                                                          user=user,
                                                          course_id=course_id)
-        return attempts != self.quiz.attempts_allowed
+        return attempts < self.quiz.attempts_allowed or self.quiz.attempts_allowed == -1
 
     def can_attempt_now(self, user, course_id):
         if self._is_attempt_allowed(user, course_id):

--- a/yaksh/views.py
+++ b/yaksh/views.py
@@ -515,23 +515,28 @@ def start(request, questionpaper_id=None, attempt_num=None, course_id=None,
     # if any previous attempt
     last_attempt = AnswerPaper.objects.get_user_last_attempt(
         quest_paper, user, course_id)
-    if last_attempt and last_attempt.is_attempt_inprogress():
-        return show_question(
-            request, last_attempt.current_question(), last_attempt,
-            course_id=course_id, module_id=module_id,
-            previous_question=last_attempt.current_question()
-        )
+
+    if last_attempt:
+        if last_attempt.is_attempt_inprogress():
+            return show_question(
+                request, last_attempt.current_question(), last_attempt,
+                course_id=course_id, module_id=module_id,
+                previous_question=last_attempt.current_question()
+            )
+        attempt_number = last_attempt.attempt_number + 1
+    else:
+        attempt_number = 1
+
     # allowed to start
     if not quest_paper.can_attempt_now(user, course_id)[0]:
         msg = quest_paper.can_attempt_now(user, course_id)[1]
         if is_moderator(user):
             return prof_manage(request, msg=msg)
-        return view_module(request, module_id=module_id, course_id=course_id,
-                           msg=msg)
-    if not last_attempt:
-        attempt_number = 1
-    else:
-        attempt_number = last_attempt.attempt_number + 1
+        return complete(
+            request, msg, last_attempt.attempt_number, quest_paper.id,
+            course_id=course_id, module_id=module_id
+        )
+
     if attempt_num is None and not quest_paper.quiz.is_exercise:
         context = {
             'user': user,


### PR DESCRIPTION
- The system will now allow student to open a quiz if status is in-progress redirect to completion page if attempts are exceeded.
- Fix the condition to evaluate the number of attempts