### PR TITLE
Fix download file for a question in quiz

### DIFF
--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -1408,6 +1408,9 @@ class FileUpload(models.Model):
             self.hide = True
         self.save()
 
+    def get_filename(self):
+        return os.path.basename(self.file.name)
+
 
 ###############################################################################
 class Answer(models.Model):

--- a/yaksh/templates/yaksh/question.html
+++ b/yaksh/templates/yaksh/question.html
@@ -160,7 +160,7 @@ question_type = "{{ question.type }}"
                                 <span> Files to download for this question </span> <hr>
                                 {% for f_name in files %}
                                   <div class="yakshwell">
-                                    <a href="{{f_name.file.url}}" class="btn btn-outline-secondary" target="_blank"><b>{{forloop.counter}}.</b> {{f_name.get_filename}}</a>
+                                    <a href="{{f_name.file.url}}" class="btn btn-outline-secondary btn-sm " target="_blank">{{f_name.get_filename}}</a>
                                     <br>
                                     </div>
                                 {% endfor %}

--- a/yaksh/templates/yaksh/question.html
+++ b/yaksh/templates/yaksh/question.html
@@ -160,7 +160,7 @@ question_type = "{{ question.type }}"
                                 <span> Files to download for this question </span> <hr>
                                 {% for f_name in files %}
                                   <div class="yakshwell">
-                                    <a href="{{f.file.url}}" class="btn btn-outline-secondary"><b>{{forloop.counter}}.</b> {{f_name.file.name}}</a>
+                                    <a href="{{f_name.file.url}}" class="btn btn-outline-secondary" target="_blank"><b>{{forloop.counter}}.</b> {{f_name.get_filename}}</a>
                                     <br>
                                     </div>
                                 {% endfor %}

--- a/yaksh/test_models.py
+++ b/yaksh/test_models.py
@@ -1,5 +1,6 @@
 import unittest
 from django.contrib.auth.models import Group
+from django.core.files.uploadedfile import SimpleUploadedFile
 from yaksh.models import User, Profile, Question, Quiz, QuestionPaper,\
     QuestionSet, AnswerPaper, Answer, Course, StandardTestCase,\
     StdIOBasedTestCase, FileUpload, McqTestCase, AssignmentUpload,\
@@ -2130,3 +2131,22 @@ class CourseStatusTestCases(unittest.TestCase):
 
         # Test get course grade after completion
         self.assertEqual(self.course.get_grade(self.answerpaper1.user), 'B')
+
+
+class FileUploadTestCases(unittest.TestCase):
+    def setUp(self):
+        self.question = Question.objects.get(summary='Q1')
+        self.filename = "uploadtest.txt"
+        self.uploaded_file = SimpleUploadedFile(self.filename, b'Test File')
+        self.file_upload = FileUpload.objects.create(
+            file=self.uploaded_file,
+            question=self.question
+        )
+
+    def test_get_file_name(self):
+        print((self.file_upload.file.path))
+        self.assertEqual(self.file_upload.get_filename(), self.filename)
+
+    def tearDown(self):
+        os.remove(self.file_upload.file.path)
+        self.file_upload.delete()


### PR DESCRIPTION
- Display just the filename instead of complete path of the file on the server. 

Closes #580