### PR TITLE
Upgrade python-social-auth 0.2.19 to social-auth-app-django 3.1.0

### DIFF
--- a/online_test/settings.py
+++ b/online_test/settings.py
@@ -43,7 +43,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'yaksh',
     'taggit',
-    'social.apps.django_app.default',
+    'social_django',
     'grades',
 )
 
@@ -56,7 +56,7 @@ MIDDLEWARE_CLASSES = (
     'yaksh.middleware.user_time_zone.TimezoneMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 )
 
 ROOT_URLCONF = 'online_test.urls'
@@ -161,8 +161,8 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
-                'social.apps.django_app.context_processors.backends',
-                'social.apps.django_app.context_processors.login_redirect',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
             'debug': False,
         }
@@ -176,8 +176,8 @@ SOCIAL_AUTH_FACEBOOK_KEY = 'FACEBOOK_KEY_PROVIDED'
 SOCIAL_AUTH_FACEBOOK_SECRET = 'FACEBOOK_SECRET_PROVIDED'
 
 AUTHENTICATION_BACKENDS = (
-    'social.backends.google.GoogleOAuth2',
-    'social.backends.facebook.FacebookOAuth2',
+    'social_core.backends.google.GoogleOAuth2',
+    'social_core.backends.facebook.FacebookOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 )
 

--- a/online_test/urls.py
+++ b/online_test/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^exam/', include('yaksh.urls', namespace='yaksh', app_name='yaksh')),
     url(r'^exam/reset/', include('yaksh.urls_password_reset')),
-    url(r'^', include('social.apps.django_app.urls', namespace='social')),
+    url(r'^', include('social_django.urls', namespace='social')),
     url(r'^grades/', include('grades.urls', namespace='grades',
                              app_name='grades')),
 ]

--- a/requirements/requirements-common.txt
+++ b/requirements/requirements-common.txt
@@ -4,7 +4,7 @@ django==1.11.18
 django-taggit==0.18.1
 pytz==2016.4
 requests-oauthlib>=0.6.1
-python-social-auth==0.2.19
+social-auth-app-django==3.1.0
 selenium==2.53.6
 coverage
 ruamel.yaml==0.15.23


### PR DESCRIPTION
Upgrade related changes.

This change requires manual intervention on the production server.

Steps to migrate have been provided here - https://github.com/omab/python-social-auth/blob/master/MIGRATING_TO_SOCIAL.md