### PR TITLE
Fixing Python version used in command line executions

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -16,7 +16,7 @@ SRC_IMAGE_NAME = 'fossee/yaksh_codeserver'
 CHECK_FILE = 'server_running.txt'
 CHECK_FILE_PATH = os.path.join(SCRIPT_DIR, 'yaksh_data', CHECK_FILE)
 OS_NAME = sys.platform
-
+PYTHON_COMMAND = "python2" if sys.version_info[0] < 3 else "python3"
 
 def create_dir(path):
     if not os.path.exists(path):
@@ -51,22 +51,22 @@ def get_cmd(run_as_cmd, base_cmd):
 @task
 def setupdb(ctx):
     print("** Setting up & migrating database **")
-    ctx.run("python manage.py makemigrations")
-    ctx.run("python manage.py migrate")
+    ctx.run("{} manage.py makemigrations".format(PYTHON_COMMAND))
+    ctx.run("{} manage.py migrate".format(PYTHON_COMMAND))
     print("** Done! Migrations complete **")
 
 
 @task
 def loadfixtures(ctx):
     print("** Loading fixtures into database **")
-    ctx.run("python manage.py loaddata demo_fixtures.json")
+    ctx.run("{} manage.py loaddata demo_fixtures.json".format(PYTHON_COMMAND))
     print("** Done! Loaded fixtures into database **")
 
 
 @task(setupdb, loadfixtures)
 def serve(ctx):
     print("** Running the Django web server. Press Ctrl-C to Exit **")
-    ctx.run("python manage.py runserver")
+    ctx.run("{} manage.py runserver".format(PYTHON_COMMAND))
 
 
 @task
@@ -102,9 +102,7 @@ def start(ctx, ports=SERVER_POOL_PORT, image=SRC_IMAGE_NAME, unsafe=False,
     if unsafe:
         with ctx.cd(SCRIPT_DIR):
             print("** Initializing local code server **")
-            base_cmd = "python{0} -m yaksh.code_server".format(
-                version
-            )
+            base_cmd = "{} -m yaksh.code_server".format(PYTHON_COMMAND)
             run_as_cmd = run_as(OS_NAME)
             cmd = get_cmd(run_as_cmd, base_cmd)
             ctx.run(cmd)
@@ -218,20 +216,20 @@ def deploy(ctx, fixtures=False, static=True):
     run_as_cmd = run_as(OS_NAME)
 
     print("** Setting up & migrating database **")
-    base_make_migrate_cmd = "docker exec -i yaksh_django" \
-        " python3 manage.py makemigrations"
+    base_make_migrate_cmd = "docker exec -i yaksh_django " \
+        " {} manage.py makemigrations".format(PYTHON_COMMAND)
     cmd = get_cmd(run_as_cmd, base_make_migrate_cmd)
     ctx.run(cmd)
 
-    base_migrate_cmd = "docker exec -i yaksh_django" \
-        " python3 manage.py migrate"
+    base_migrate_cmd = "docker exec -i yaksh_django " \
+        "{} manage.py migrate".format(PYTHON_COMMAND)
     cmd = get_cmd(run_as_cmd, base_migrate_cmd)
     ctx.run(cmd)
     print("** Done! Migrations complete **")
 
     if fixtures:
-        base_fixture_cmd = "docker exec -i yaksh_django" \
-            " python3 manage.py loaddata demo_fixtures.json"
+        base_fixture_cmd = "docker exec -i yaksh_django " \
+            "{} manage.py loaddata demo_fixtures.json".format(PYTHON_COMMAND)
         cmd = get_cmd(run_as_cmd, base_fixture_cmd)
         print("** Loading fixtures into database **")
         ctx.run(cmd)
@@ -239,7 +237,7 @@ def deploy(ctx, fixtures=False, static=True):
 
     if static:
         base_static_cmd = "docker exec -i yaksh_django " \
-            "python3 manage.py collectstatic"
+            "{} manage.py collectstatic".format(PYTHON_COMMAND)
         cmd = get_cmd(run_as_cmd, base_static_cmd)
         print("** Setting up static assets **")
         ctx.run(cmd)


### PR DESCRIPTION
Python version used for command line execution differs through the file. This has been fixed by creating a variable that unifies the same.