### PR TITLE
Remove 'copy of' string in _create_lesson_copy()

### DIFF
--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -296,7 +296,7 @@ class Lesson(models.Model):
         lesson_files = self.get_files()
         new_lesson = self
         new_lesson.id = None
-        new_lesson.name = "Copy of {0}".format(self.name)
+        new_lesson.name = self.name
         new_lesson.creator = user
         new_lesson.save()
         for _file in lesson_files:
@@ -575,7 +575,7 @@ class Quiz(models.Model):
         question_papers = self.questionpaper_set.all()
         new_quiz = self
         new_quiz.id = None
-        new_quiz.description = "Copy of {0}".format(self.description)
+        new_quiz.description = self.description
         new_quiz.creator = user
         new_quiz.save()
         for qp in question_papers:
@@ -932,7 +932,7 @@ class Course(models.Model):
         copy_course_name = "Copy Of {0}".format(self.name)
         new_course = self._create_duplicate_instance(user, copy_course_name)
         for module in learning_modules:
-            copy_module_name = "Copy of {0}".format(module.name)
+            copy_module_name = module.name
             new_module = module._create_module_copy(user, copy_module_name)
             new_course.learning_module.add(new_module)
         return new_course

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -296,7 +296,6 @@ class Lesson(models.Model):
         lesson_files = self.get_files()
         new_lesson = self
         new_lesson.id = None
-        new_lesson.name = self.name
         new_lesson.creator = user
         new_lesson.save()
         for _file in lesson_files:
@@ -575,7 +574,6 @@ class Quiz(models.Model):
         question_papers = self.questionpaper_set.all()
         new_quiz = self
         new_quiz.id = None
-        new_quiz.description = self.description
         new_quiz.creator = user
         new_quiz.save()
         for qp in question_papers:
@@ -821,12 +819,13 @@ class LearningModule(models.Model):
             percent = round((count / units.count()) * 100)
         return percent
 
-    def _create_module_copy(self, user, module_name):
+    def _create_module_copy(self, user, module_name=None):
         learning_units = self.learning_unit.order_by("order")
         new_module = self
         new_module.id = None
-        new_module.name = module_name
         new_module.creator = user
+        if module_name:
+            new_module.name = module_name
         new_module.save()
         for unit in learning_units:
             new_unit = unit._create_unit_copy(user)
@@ -933,7 +932,7 @@ class Course(models.Model):
         new_course = self._create_duplicate_instance(user, copy_course_name)
         for module in learning_modules:
             copy_module_name = module.name
-            new_module = module._create_module_copy(user, copy_module_name)
+            new_module = module._create_module_copy(user)
             new_course.learning_module.add(new_module)
         return new_course
 

--- a/yaksh/test_views.py
+++ b/yaksh/test_views.py
@@ -2166,7 +2166,8 @@ class TestCourses(TestCase):
         # Teacher Login
         # Given
         # Add files to a lesson
-        lesson_file = SimpleUploadedFile("file1.txt", b"Test")
+        file_content = b"Test"
+        lesson_file = SimpleUploadedFile("file1.txt", file_content)
         django_file = File(lesson_file)
         lesson_file_obj = LessonFile()
         lesson_file_obj.lesson = self.lesson
@@ -2201,18 +2202,18 @@ class TestCourses(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(courses.last().creator, self.teacher)
         self.assertEqual(courses.last().name, "Copy Of Python Course")
-        self.assertEqual(module.name, "Copy of demo module")
+        self.assertEqual(module.name, "demo module")
         self.assertEqual(module.creator, self.teacher)
         self.assertEqual(module.order, 0)
         self.assertEqual(len(units), 2)
-        self.assertEqual(cloned_lesson.name, "Copy of demo lesson")
+        self.assertEqual(cloned_lesson.name, "demo lesson")
         self.assertEqual(cloned_lesson.creator, self.teacher)
-        self.assertEqual(cloned_quiz.description, "Copy of demo quiz")
+        self.assertEqual(cloned_quiz.description, "demo quiz")
         self.assertEqual(cloned_quiz.creator, self.teacher)
         self.assertEqual(cloned_qp.__str__(),
-                         "Question Paper for Copy of demo quiz")
-        self.assertEqual(os.path.basename(expected_lesson_files[0].file.name),
-                         os.path.basename(actual_lesson_files[0].file.name))
+                         "Question Paper for demo quiz")
+        self.assertTrue(expected_lesson_files.exists())
+        self.assertEquals(expected_lesson_files[0].file.read(), file_content)
 
         for lesson_file in self.all_files:
             file_path = lesson_file.file.path

--- a/yaksh/views.py
+++ b/yaksh/views.py
@@ -224,6 +224,9 @@ def results_user(request):
 @email_verified
 def add_question(request, question_id=None):
     user = request.user
+    if not is_moderator(user):
+        raise Http404('You are not allowed to view this page !')
+
     test_case_type = None
 
     if question_id is not None:


### PR DESCRIPTION
- Remove Copy Of in Module, Lesson and Quiz names when duplicating courses

- Prevent student users from accessing Questions