### PR TITLE
[FIX] #546 - create_moderator command if User has no Profile

### DIFF
--- a/yaksh/management/commands/create_moderator.py
+++ b/yaksh/management/commands/create_moderator.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User, Group, Permission
 
 # local imports
 from yaksh.models import create_group
+from yaksh.views import _create_or_update_profile
 
 
 class Command(BaseCommand):
@@ -43,6 +44,10 @@ class Command(BaseCommand):
                         )
                     )
                 else:
+                    if not hasattr(user, 'profile'):
+                        _create_or_update_profile(user,
+                                                  {'is_email_verified': True}
+                                                  )
                     user.profile.is_moderator = True
                     user.profile.save()
                     self.stdout.write(

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -1279,7 +1279,7 @@ class Profile(models.Model):
         super(Profile, self).save(*args, **kwargs)
 
     def __str__(self):
-        return '%s' % (self.user.get_full_name())
+        return '%s' % (self.user.get_full_name() or self.user.username)
 
 
 ###############################################################################


### PR DESCRIPTION
This fixes #546
 
Previously create_moderator command was failing as per the mentioned git issue. So, this PR changes will check for the user profile first, if the user has a profile then it will continue the default flow but if not then will create the profile first(with verified email) and then continue the default flow.

One more change that has been done in the mode query representation in the Django Admin panel. Previously it was fetching the user full name. Now, it will display a full name or username in the Profile model.