### PR TITLE
Avoid duplicate user entry with same email address during upload.

### DIFF
--- a/yaksh/fixtures/user_existing_email.csv
+++ b/yaksh/fixtures/user_existing_email.csv
@@ -1,0 +1,2 @@
+firstname, lastname, email
+abc, abc, demo_student@test.com

--- a/yaksh/fixtures/users_add_update_reject.csv
+++ b/yaksh/fixtures/users_add_update_reject.csv
@@ -1,4 +1,4 @@
 firstname, lastname, email, institute,department,roll_no,remove,password,username
 test, test, test@g.com, TEST, TEST, TEST101, FALSE, TEST, test
-test2, test, test@g.com, TEST, TEST, TEST101, FALSE, TEST, test2
-test2, test, test@g.com, TEST, TEST, TEST101, TRUE, TEST, test2
+test2, test, test2@g.com, TEST, TEST, TEST101, FALSE, TEST, test2
+test2, test, test2@g.com, TEST, TEST, TEST101, TRUE, TEST, test2

--- a/yaksh/views.py
+++ b/yaksh/views.py
@@ -2409,8 +2409,10 @@ def _read_user_csv(request, reader, course):
             messages.info(request, "{0} -- Missing Values".format(counter))
             continue
         users = User.objects.filter(username=username)
+        if not users.exists():
+            users = User.objects.filter(email=email)
         if users.exists():
-            user = users[0]
+            user = users.last()
             if remove.strip().lower() == 'true':
                 _remove_from_course(user, course)
                 messages.info(request, "{0} -- {1} -- User rejected".format(


### PR DESCRIPTION
Django allows multiple usernames with same email id.
Preventing this, as we identify users with their email id or username.
closes #743 