### PR TITLE
Show max marks for all attempts in answerpaper

### DIFF
--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -2305,6 +2305,17 @@ class AnswerPaper(models.Model):
                     'answer': answer,
                     'error_list': [e for e in json.loads(answer.error)]
                 }]
+
+        for question, answers in q_a.items():
+            answers = q_a[question]
+            q_a[question].append({
+                'marks': max([
+                    answer['answer'].marks
+                        for answer in answers
+                            if question == answer['answer'].question
+                ])
+            })
+
         return q_a
 
     def get_latest_answer(self, question_id):

--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -2311,8 +2311,8 @@ class AnswerPaper(models.Model):
             q_a[question].append({
                 'marks': max([
                     answer['answer'].marks
-                        for answer in answers
-                            if question == answer['answer'].question
+                    for answer in answers
+                    if question == answer['answer'].question
                 ])
             })
 

--- a/yaksh/templates/yaksh/user_data.html
+++ b/yaksh/templates/yaksh/user_data.html
@@ -74,19 +74,17 @@
                 </tr>
                 </thead>
                 <tbody>
-                {% for question, answers in paper.get_question_answers.items %}
-                  {% with answers|last as answer %}
-                      <tr>
+                  {% for question, answers in paper.get_question_answers.items %}
+                    <tr>
+                      <td>{{question.summary}}</td>
+                      <td>{{question.type}}</td>
                       <td>
-                        <a href="#question_{{question.id}}">
-                          {{ question.summary }}
-                        </a>
+                        {% for answer in answers %}
+                          {{answer.marks}}
+                        {% endfor %}
                       </td>
-                      <td>{{ question.type }}</td>
-                      <td>{{ answer.answer.marks }}</td>
-                      </tr>
-                  {% endwith %}
-                {% endfor %}
+                    </tr>
+                  {% endfor %}
                 </tbody>
             </table>
             {% for question, answers in paper.get_question_answers.items %}
@@ -313,12 +311,12 @@
                 <div class="col-md-2">
                   <label class="col-form-label" for="q{{ question.id }}">Marks:</label>
                   {% with answers|last as answer %}
-                  <input id="q{{ question.id }}" type="text" name="q{{ question.id }}_marks" size="4" class="form-control" value="{{ answer.answer.marks }}" readonly=""><br><br>
+                    <input id="q{{ question.id }}" type="text" name="q{{ question.id }}_marks" size="4" class="form-control" value="{{ answer.marks }}" readonly=""><br><br>
                   {% endwith %}
                 </div>
               </div>
               <hr/>
-              {% endfor %} {# for question, answers ... #}
+            {% endfor %} {# for question, answers ... #}
               <div class="form-group">
                 <h3>Teacher comments: </h3>
                 <textarea id="comments_{{paper.question_paper.id}}" class="form-control"

--- a/yaksh/test_models.py
+++ b/yaksh/test_models.py
@@ -1654,12 +1654,14 @@ class AnswerPaperTestCases(unittest.TestCase):
             answers_saved = Answer.objects.filter(question=question)
             error_list = [json.loads(ans.error) for ans in answers_saved]
             if answers_saved:
-                self.assertEqual(len(answered[question]), len(answers_saved))
+                self.assertGreater(len(answered[question]), len(answers_saved))
                 ans = []
                 err = []
                 for val in answered[question]:
-                    ans.append(val.get('answer'))
-                    err.append(val.get('error_list'))
+                    if val.get('answer') is not None:
+                        ans.append(val.get('answer'))
+                    if val.get('error_list') is not None:
+                        err.append(val.get('error_list'))
                 self.assertEqual(set(ans), set(answers_saved))
                 self.assertEqual(error_list, err)
 

--- a/yaksh/views.py
+++ b/yaksh/views.py
@@ -1757,7 +1757,6 @@ def user_data(request, user_id, questionpaper_id=None, course_id=None):
         raise Http404('You are not allowed to view this page!')
     user = User.objects.get(id=user_id)
     data = AnswerPaper.objects.get_user_data(user, questionpaper_id, course_id)
-
     context = {'data': data, 'course_id': course_id}
     return my_render_to_response(request, 'yaksh/user_data.html', context)
 


### PR DESCRIPTION
- Latest attempt marks were shown in the answerpaper, which made
  it difficult to analyze the paper. This PR fixes the issue
  and the best marks of all the attempt are provided.