### PR TITLE
feat: add keycloak OIDC SSO 

### DIFF
--- a/docker/Dockerfile_codeserver
+++ b/docker/Dockerfile_codeserver
@@ -1,4 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 MAINTAINER FOSSEE <pythonsupport@fossee.in>
 

--- a/docker/Dockerfile_django
+++ b/docker/Dockerfile_django
@@ -1,4 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 MAINTAINER FOSSEE <pythonsupport@fossee.in>
 
@@ -10,7 +12,7 @@ VOLUME /Sites/online_test
 
 ADD Files/requirements-* /tmp/
 
-RUN cd /Sites/online_test && pip3 install -r /tmp/requirements-py3.txt 
+RUN cd /Sites/online_test && pip3 install -r /tmp/requirements-common.txt && pip3 install -r /tmp/requirements-production.txt 
 
 ADD Files/000-default.conf /etc/apache2/sites-enabled/
 

--- a/docker/Files/requirements-codeserver.txt
+++ b/docker/Files/requirements-codeserver.txt
@@ -1,0 +1,6 @@
+pytest
+python-decouple
+requests
+tornado==4.5.3
+psutil
+nose==1.3.7

--- a/docker/Files/requirements-common.txt
+++ b/docker/Files/requirements-common.txt
@@ -1,0 +1,27 @@
+-r requirements-codeserver.txt
+invoke==0.21.0
+django==3.1.7
+django-taggit==1.2.0
+pytz==2019.3
+requests-oauthlib>=0.6.1
+social-auth-app-django==3.1.0
+selenium==2.53.6
+coverage
+ruamel.yaml==0.16.10
+pyyaml==5.3.1
+markdown==2.6.9
+pygments==2.2.0
+celery==4.4.2
+redis==3.4.1
+notifications-plugin==0.1.2
+django-celery-beat==2.0.0
+django-celery-results==1.2.1
+djangorestframework==3.11.2
+django-cors-headers==3.1.0
+Pillow
+pandas
+qrcode
+more-itertools==8.4.0
+django-storages==1.11.1
+boto3==1.17.17
+mozilla-django-oidc

--- a/docker/Files/requirements-common.txt
+++ b/docker/Files/requirements-common.txt
@@ -24,4 +24,4 @@ qrcode
 more-itertools==8.4.0
 django-storages==1.11.1
 boto3==1.17.17
-mozilla-django-oidc
+mozilla_django_oidc

--- a/docker/Files/requirements-production.txt
+++ b/docker/Files/requirements-production.txt
@@ -1,0 +1,2 @@
+-r requirements-common.txt
+mysqlclient==1.4.6

--- a/online_test/settings.py
+++ b/online_test/settings.py
@@ -56,7 +56,8 @@ INSTALLED_APPS = (
     'api',
     'corsheaders',
     'rest_framework.authtoken',
-    'storages'
+    'storages',
+    'mozilla-django-oidc',
 )
 
 MIDDLEWARE = (
@@ -195,9 +196,21 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = 'GOOGLE_SECRET_PROVIDED'
 SOCIAL_AUTH_FACEBOOK_KEY = 'FACEBOOK_KEY_PROVIDED'
 SOCIAL_AUTH_FACEBOOK_SECRET = 'FACEBOOK_SECRET_PROVIDED'
 
+OIDC_RP_CLIENT_ID = 'your_client_id'
+OIDC_RP_CLIENT_SECRET = 'your_client_secret'
+
+OIDC_OP_AUTHORIZATION_ENDPOINT = 'http://your_keycloak_url/realms/your_keycloak_realm/protocol/openid-connect/auth'
+OIDC_OP_TOKEN_ENDPOINT = 'http://your_keycloak_url/realms/your_keycloak_realm/protocol/openid-connect/token'
+OIDC_OP_USER_ENDPOINT = 'http://your_keycloak_url/realms/your_keycloak_realm/protocol/openid-connect/userinfo'
+OIDC_RP_SIGN_ALGO = 'RS256'
+OIDC_OP_JWKS_ENDPOINT = 'http://your_keycloak_url/realms/your_keycloak_realm/protocol/openid-connect/certs'
+OIDC_OP_LOGOUT_ENDPOINT = 'http://your_keycloak_url/realms/your_keycloak_realm/protocol/openid-connect/logout'
+OIDC_STORE_ID_TOKEN = True
+
 AUTHENTICATION_BACKENDS = (
     'social_core.backends.google.GoogleOAuth2',
     'social_core.backends.facebook.FacebookOAuth2',
+    'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
     'django.contrib.auth.backends.ModelBackend',
 )
 

--- a/online_test/settings.py
+++ b/online_test/settings.py
@@ -57,7 +57,7 @@ INSTALLED_APPS = (
     'corsheaders',
     'rest_framework.authtoken',
     'storages',
-    'mozilla-django-oidc',
+    'mozilla_django_oidc',
 )
 
 MIDDLEWARE = (

--- a/online_test/urls.py
+++ b/online_test/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     url(r'^api/', include('api.urls', namespace='api')),
     url(r'^stats/', include('stats.urls', namespace='stats')),
     url(r'^flatfiles/', include(('upload.urls', 'upload'))),
+    url(r"^oidc/", include("mozilla_django_oidc.urls")),
 
 ]
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/yaksh/templates/yaksh/login.html
+++ b/yaksh/templates/yaksh/login.html
@@ -32,6 +32,12 @@
               </span>
               <span class="btn-inner--text">Facebook</span>
             </a>
+            <a href="{% url 'oidc_authentication_init' %}" class="btn btn-neutral btn-icon">
+              <span class="btn-inner--icon">
+                <i class="fa fa-key"></i>
+              </span>
+              <span class="btn-inner--text">Keycloak</span>
+            </a>
           </div>
         </div>
         <div class="card-body px-lg-5 py-lg-5">


### PR DESCRIPTION
Integrate keycloak oidc sso with online-test application 

Changes made
- Upgrade base image from ubunut:16.04 to ubuntu:20.04
- Added the `mozilla_django_oidc` module to enable OIDC authentication with Keycloak.
- Updated authentication settings and application configuration to support SSO.

For detailed setup, configuration, and usage, please refer to the [documentation](https://github.com/kjswaruph/fossee-daily-progress/blob/main/online-test/Task.md).