### PR TITLE
Fix file upload path and add question link

### DIFF
--- a/yaksh/models.py
+++ b/yaksh/models.py
@@ -1457,7 +1457,7 @@ class Question(models.Model):
                 ]
             else:
                 metadata['file_paths'] = [
-                    (self.get_file_url(file.file.url), file.extract)
+                    (file.file.path, file.extract)
                      for file in files
                 ]
         if self.type == "upload" and regrade:

--- a/yaksh/templates/yaksh/showquestions.html
+++ b/yaksh/templates/yaksh/showquestions.html
@@ -133,16 +133,16 @@
         <form name=frm action="{% url 'yaksh:show_questions' %}" method="post">
           {% csrf_token %}
           <div id="filtered-questions">
+                <div class="col">
+                  <a class="btn btn-lg btn-success" href="{% url 'yaksh:add_question' %}">
+                    <i class="fa fa-plus-circle"></i>&nbsp;Add Question
+                  </a>
+                </div>
             <br>
             {% if objects %}
               <div class="row">
                 <div class="col">
                 {% include "yaksh/paginator.html" %}
-                </div>
-                <div class="col">
-                  <a class="btn btn-lg btn-success" href="{% url 'yaksh:add_question' %}">
-                    <i class="fa fa-plus-circle"></i>&nbsp;Add Question
-                  </a>
                 </div>
               </div>
               <br>

--- a/yaksh/test_models.py
+++ b/yaksh/test_models.py
@@ -1353,6 +1353,13 @@ class AnswerPaperTestCases(unittest.TestCase):
         )
         self.mcc_based_testcase.save()
 
+        self.filename = "test.txt"
+        self.uploaded_file = SimpleUploadedFile(self.filename, b'Test File')
+        self.file_upload = FileUpload.objects.create(
+            file=self.uploaded_file,
+            question=self.question1
+        )
+
         # Setup quiz where questions are shuffled
         # Create Quiz and Question Paper
         self.quiz2 = Quiz.objects.get(description="demo quiz 2")
@@ -1412,6 +1419,7 @@ class AnswerPaperTestCases(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         self.quiz.questionpaper_set.all().delete()
+        self.file_upload.delete()
         self.server_pool.stop()
         self.server_thread.join()
         settings.code_evaluators['python']['standardtestcase'] = \


### PR DESCRIPTION
### Summary
- File upload path is needed instead of file upload url for interaction at CLI level.
- Add Question button was not available after initial setup.

### Changes
- file.path used instead of file.url in this case
- Added the **Add Question** button

### Testing
- Modified tests to catch this
- Ran automated tests successfully
- Add Question button tested manually

Fixes #872 
Fixes #873 