### PR TITLE
Improve feedback for failed test cases

### DIFF
--- a/yaksh/custom_assertion_message.py
+++ b/yaksh/custom_assertion_message.py
@@ -1,5 +1,16 @@
+from nose.tools import assert_almost_equal
+
+try:
+    import numpy as np
+    from numpy.testing import assert_allclose
+except:
+    np = None
+    assert_allclose = None
+
+
 class CustomAssertionError(AssertionError):
     pass
+
 
 def safe_repr(value):
     try:
@@ -7,41 +18,79 @@ def safe_repr(value):
     except Exception:
         return "<unrepresentable value>"
 
-def check_equal(target_name, input_description, actual_callable, expected,
-                reveal_expected=False, hint=None):
+
+def is_numpy_value(value):
+    return np is not None and isinstance(value, np.ndarray)
+
+
+def _raise_eval_error(expression, exc):
+    message = (
+        "We called `%s`.\n"
+        "The code raised an error instead of returning the expected result.\n"
+        "Error: %s: %s\n"
+        "Kindly debug your code."
+        % (expression, type(exc).__name__, str(exc))
+    )
+
+    raise CustomAssertionError(message)
+
+
+def _raise_comparison_error(expression, actual, exc):
+    message = (
+        "We called `%s`.\n"
+        "Your code returned: %s\n"
+        "Comparing your output with the expected output raised an error.\n"
+        "Comparison error: %s: %s"
+        % (expression, safe_repr(actual), type(exc).__name__, str(exc))
+    )
+
+    raise CustomAssertionError(message)
+
+
+def _raise_failure_message(expression, actual, expected, reveal_expected=True,
+                           hint=None, tolerance=None, details=None):
+    lines = [
+        "We called `%s`." % expression,
+    ]
+
+    if reveal_expected:
+        if tolerance is None:
+            lines.append("Expected output: %s" % safe_repr(expected))
+        else:
+            lines.append(
+                "Expected output: %s with tolerance ±%s"
+                % (safe_repr(expected), safe_repr(tolerance))
+            )
+    else:
+        lines.append("The result did not match the expected behavior.")
+
+    lines.append("Your code returned: %s" % safe_repr(actual))
+
+    if details:
+        lines.append("Details: %s" % details)
+
+    if hint is not None:
+        lines.append("Hint: %s" % hint)
+
+    raise CustomAssertionError("\n".join(lines))
+
+
+def _set_scope(g, l):
+    if g is None:
+        globals_ = {}
+    if l is None:
+        locals_ = {}
+
+
+def check_equal(expression, expected, reveal_expected=True, hint=None,
+        globals_=None, locals_=None):
     """
-    Compare a student's actual result with an expected result and raise a
-    readable assertion error if they do not match.
+    Simple usage:
 
-    Parameters:
-        target_name (str):
-            The name of the function or method being tested.
-            Examples: "is_palindrome", "add", "MyClass.method".
+        check_equal("add(1, 2)", 3)
 
-        input_description (str):
-            A human-readable description of the input or object state used in
-            the test.
-            Examples: '"hello"', "2, 3".
-
-        actual_callable:
-            A callable, usually a lambda, that runs the student's code and
-            returns the actual result.
-            Example: lambda: is_palindrome("hello")
-
-            A direct value may also be passed, but a callable is preferred
-            because it allows this helper to catch runtime errors and convert
-            them into readable feedback.
-
-        expected:
-            The expected result to compare against the student's actual result.
-
-        hint (str, optional):
-            Optional guidance shown to the student when the test fails.
-
-        reveal_expected (bool, optional):
-            If True, include the expected output in the feedback message.
-            If False, hide the expected output and only say that the result did
-            not match the expected behavior.
+    It evaluates the expression string, compares result with expected,
+    and raises readable feedback if it fails.
 
     Raises:
         CustomAssertionError:
@@ -53,45 +102,41 @@ def check_equal(target_name, input_description, actual_callable, expected,
             Returns silently when the actual result equals the expected result.
     """
 
-    if '.' in target_name:
-        target_type = "method"
-    else:
-        target_type = "function"
+    _set_scope(globals_, locals_)
 
-    first_line = "Your %s `%s` was tested using %s." % (
-            target_type, target_name, input_description,
-        )
     try:
-        if callable(actual_callable):
-            actual = actual_callable()
-        else:
-            actual = actual_callable
+        actual = eval(expression, globals_, locals_)
     except Exception as e:
-        message = (
-            "%s\n"
-            "The code raised an error instead of returning "
-            "the expected result.\n"
-            "Error observed: %s: %s\n"
-            "Kindly debug your code."%(first_line, type(e).__name__, str(e),)
-        )
+        raise _raise_eval_error(expression, e)
 
-        raise CustomAssertionError(message)
+    try:
+        matched = actual == expected
+        if matched:
+            return
+    except Exception as e:
+        raise _raise_comparison_error(expression, actual, e)
 
-    if actual == expected:
-        return
+    raise _raise_failure_message(expression, actual, expected,
+        reveal_expected, hint)
 
-    lines = [first_line]
 
-    if reveal_expected:
-        lines.append("Expected output: %s" % safe_repr(expected))
-    else:
-        lines.append("The result did not match the expected behaviour")
+def check_almost_equal(expression, expected, tolerance=0.001, rtol=0,
+    reveal_expected=True, hint=None, globals_=None, locals_=None):
 
-    lines.append("Your code returned: %s" % safe_repr(actual))
+    _set_scope(globals_, locals_)
 
-    if hint is not None:
-        lines.append("Hint: %s" % hint)
+    try:
+        actual = eval(expression, globals_, locals_)
+    except Exception as e:
+        raise _raise_eval_error(expression, e)
 
-    message = "\n".join(lines)
-
-    raise CustomAssertionError(message)
+    try:
+        if is_numpy_value(actual) or is_numpy_value(expected):
+            assert_allclose(actual, expected, atol=tolerance, rtol=rtol)
+        else:
+            assert_almost_equal(actual, expected, delta=tolerance)
+    except AssertionError as e:
+        raise _raise_failure_message(expression, actual, expected,
+            reveal_expected, hint, tolerance, details=str(e))
+    except Exception as e:
+        raise _raise_comparison_error(expression, safe_repr(actual), e)

--- a/yaksh/custom_assertion_message.py
+++ b/yaksh/custom_assertion_message.py
@@ -1,0 +1,97 @@
+class CustomAssertionError(AssertionError):
+    pass
+
+def safe_repr(value):
+    try:
+        return repr(value)
+    except Exception:
+        return "<unrepresentable value>"
+
+def check_equal(target_name, input_description, actual_callable, expected,
+                reveal_expected=False, hint=None):
+    """
+    Compare a student's actual result with an expected result and raise a
+    readable assertion error if they do not match.
+
+    Parameters:
+        target_name (str):
+            The name of the function or method being tested.
+            Examples: "is_palindrome", "add", "MyClass.method".
+
+        input_description (str):
+            A human-readable description of the input or object state used in
+            the test.
+            Examples: '"hello"', "2, 3".
+
+        actual_callable:
+            A callable, usually a lambda, that runs the student's code and
+            returns the actual result.
+            Example: lambda: is_palindrome("hello")
+
+            A direct value may also be passed, but a callable is preferred
+            because it allows this helper to catch runtime errors and convert
+            them into readable feedback.
+
+        expected:
+            The expected result to compare against the student's actual result.
+
+        hint (str, optional):
+            Optional guidance shown to the student when the test fails.
+
+        reveal_expected (bool, optional):
+            If True, include the expected output in the feedback message.
+            If False, hide the expected output and only say that the result did
+            not match the expected behavior.
+
+    Raises:
+        CustomAssertionError:
+            Raised when the student's result does not match the expected result,
+            or when the student's code raises an exception while being tested.
+
+    Returns:
+        None:
+            Returns silently when the actual result equals the expected result.
+    """
+
+    if '.' in target_name:
+        target_type = "method"
+    else:
+        target_type = "function"
+
+    first_line = "Your %s `%s` was tested using %s." % (
+            target_type, target_name, input_description,
+        )
+    try:
+        if callable(actual_callable):
+            actual = actual_callable()
+        else:
+            actual = actual_callable
+    except Exception as e:
+        message = (
+            "%s\n"
+            "The code raised an error instead of returning "
+            "the expected result.\n"
+            "Error observed: %s: %s\n"
+            "Kindly debug your code."%(first_line, type(e).__name__, str(e),)
+        )
+
+        raise CustomAssertionError(message)
+
+    if actual == expected:
+        return
+
+    lines = [first_line]
+
+    if reveal_expected:
+        lines.append("Expected output: %s" % safe_repr(expected))
+    else:
+        lines.append("The result did not match the expected behaviour")
+
+    lines.append("Your code returned: %s" % safe_repr(actual))
+
+    if hint is not None:
+        lines.append("Hint: %s" % hint)
+
+    message = "\n".join(lines)
+
+    raise CustomAssertionError(message)

--- a/yaksh/error_messages.py
+++ b/yaksh/error_messages.py
@@ -17,16 +17,15 @@ def prettify_exceptions(exception, message, traceback=None,
     if exception in ignore_traceback:
         err["traceback"] = None
 
-    if exception == 'AssertionError':
-        value = ("Expected answer from the" +
-                 " test case did not match the output")
-        if message:
-            err["message"] = message
-        else:
-            err["message"] = value
-        err["traceback"] = None
     err["test_case"] = testcase
     err["line_no"] = line_no
+    if exception == 'AssertionError' or exception == 'Errors':
+        value = ("Expected answer from the" +
+                 " test case did not match the output")
+        err['message'] = value
+        if message:
+            err["test_case"] = message
+        err["traceback"] = None
     return err
 
 

--- a/yaksh/evaluator_tests/test_python_evaluation.py
+++ b/yaksh/evaluator_tests/test_python_evaluation.py
@@ -473,7 +473,7 @@ class PythonAssertionEvaluationTestCases(EvaluatorBaseTest):
         self.assertFalse(result.get("success"))
         error = result.get("error")[0]
         self.assertEqual(error['exception'], 'AssertionError')
-        self.assertEqual(error['message'], '-1 != 3')
+        self.assertIn('did not match the output', error['message'])
 
 
 class PythonStdIOEvaluationTestCases(EvaluatorBaseTest):

--- a/yaksh/python_assertion_evaluator.py
+++ b/yaksh/python_assertion_evaluator.py
@@ -7,7 +7,9 @@ from .file_utils import copy_files, delete_files
 from .base_evaluator import BaseEvaluator
 from .grader import TimeoutException
 from .error_messages import prettify_exceptions
-from .custom_assertion_message import CustomAssertionError, check_equal
+from .custom_assertion_message import (
+        CustomAssertionError, check_equal, check_almost_equal
+)
 
 
 class PythonAssertionEvaluator(BaseEvaluator):
@@ -67,16 +69,32 @@ class PythonAssertionEvaluator(BaseEvaluator):
         """
         success = False
         mark_fraction = 0.0
+        self.exec_scope["CustomAssertionError"] = CustomAssertionError
+
+
+        def _check_equal(expression, expected, reveal_expected=True, hint=None):
+            return check_equal(expression, expected,
+                reveal_expected=reveal_expected, hint=hint,
+                globals_=self.exec_scope, locals_=self.exec_scope,
+            )
+
+        def _check_almost_equal(expression, expected, tolerance,
+            reveal_expected=True, hint=None):
+            return check_almost_equal(expression, expected, tolerance,
+                reveal_expected=reveal_expected, hint=hint,
+                globals_=self.exec_scope, locals_=self.exec_scope,
+            )
+
+        self.exec_scope["check_equal"] = _check_equal
+        self.exec_scope["check_almost_equal"] = _check_almost_equal
         try:
             exec("from nose.tools import *", self.exec_scope)
-            self.exec_scope["CustomAssertionError"] = CustomAssertionError
-            self.exec_scope["check_equal"] = check_equal
             _tests = compile(self.test_case, '<string>', mode='exec')
             exec(_tests, self.exec_scope)
         except TimeoutException:
             raise
         except CustomAssertionError as e:
-            err = prettify_exceptions("AssertionError", message=None, testcase=str(e))
+            err = prettify_exceptions("Errors", message=None, testcase=str(e))
         except Exception:
             exc_type, exc_value, exc_tb = sys.exc_info()
             tb_list = traceback.format_exception(exc_type, exc_value, exc_tb)

--- a/yaksh/python_assertion_evaluator.py
+++ b/yaksh/python_assertion_evaluator.py
@@ -7,6 +7,7 @@ from .file_utils import copy_files, delete_files
 from .base_evaluator import BaseEvaluator
 from .grader import TimeoutException
 from .error_messages import prettify_exceptions
+from .custom_assertion_message import CustomAssertionError, check_equal
 
 
 class PythonAssertionEvaluator(BaseEvaluator):
@@ -68,10 +69,14 @@ class PythonAssertionEvaluator(BaseEvaluator):
         mark_fraction = 0.0
         try:
             exec("from nose.tools import *", self.exec_scope)
+            self.exec_scope["CustomAssertionError"] = CustomAssertionError
+            self.exec_scope["check_equal"] = check_equal
             _tests = compile(self.test_case, '<string>', mode='exec')
             exec(_tests, self.exec_scope)
         except TimeoutException:
             raise
+        except CustomAssertionError as e:
+            err = prettify_exceptions("AssertionError", message=None, testcase=str(e))
         except Exception:
             exc_type, exc_value, exc_tb = sys.exc_info()
             tb_list = traceback.format_exception(exc_type, exc_value, exc_tb)

--- a/yaksh/templates/yaksh/error_template.html
+++ b/yaksh/templates/yaksh/error_template.html
@@ -1,6 +1,11 @@
 {% load static %}
 {% block css%}
   <link rel="stylesheet" href="{% static 'yaksh/css/dashboard.css' %}" type="text/css" />
+  <style>
+  #my-text {
+    white-space: pre-line; /* Tells HTML to render \n as line breaks */
+  }
+</style>
 {% endblock %}
 {% block script %}
   <script src="{% static 'yaksh/js/jquery-ui.js' %}"></script>
@@ -23,10 +28,11 @@
 
         {% if error.test_case %}
           <strong> We tried your code with the following test case:</strong>
-          <br/></br>
-          <pre><code><strong class="text-danger">
+          <div id="my-text">
+          <code><strong class="text-danger">
           {{error.test_case}}
-          </strong></code></pre>
+          </strong></code>
+          </div>
         {% endif %}
         <p> <b>The following error took place: </b></p>
         <table class="table  table-borderless border border-danger table-responsive-sm" width="100%" id='assertion'>


### PR DESCRIPTION
## Summary

Adds a custom `check_equal` test helper to generate more readable, user-friendly feedback
for failed Python test cases.

<img width="1358" height="695" alt="err" src="https://github.com/user-attachments/assets/aa2cd79c-86af-4ca0-9d32-4fcfc358a0fd" />

Fixes #875 